### PR TITLE
feat: 로그인/로그아웃 기능 구현

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/auth/request/LoginRequest.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/auth/request/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.swcampus.api.auth.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다")
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+}

--- a/sw-campus-api/src/main/java/com/swcampus/api/auth/response/LoginResponse.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/auth/response/LoginResponse.java
@@ -1,0 +1,37 @@
+package com.swcampus.api.auth.response;
+
+import com.swcampus.domain.auth.LoginResult;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private Long userId;
+    private String email;
+    private String name;
+    private String nickname;
+    private String role;
+
+    // ORGANIZATION인 경우만 포함
+    private Long organizationId;
+    private String organizationName;
+    private String approvalStatus;
+
+    public static LoginResponse from(LoginResult result) {
+        LoginResponseBuilder builder = LoginResponse.builder()
+                .userId(result.getMember().getId())
+                .email(result.getMember().getEmail())
+                .name(result.getMember().getName())
+                .nickname(result.getMember().getNickname())
+                .role(result.getMember().getRole().name());
+
+        if (result.getOrganization() != null) {
+            builder.organizationId(result.getOrganization().getId())
+                    .organizationName(result.getOrganization().getName())
+                    .approvalStatus(result.getOrganization().getApprovalStatus().name());
+        }
+
+        return builder.build();
+    }
+}

--- a/sw-campus-api/src/main/java/com/swcampus/api/exception/GlobalExceptionHandler.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.swcampus.domain.auth.exception.CertificateRequiredException;
 import com.swcampus.domain.auth.exception.DuplicateEmailException;
 import com.swcampus.domain.auth.exception.EmailNotVerifiedException;
 import com.swcampus.domain.auth.exception.EmailVerificationExpiredException;
+import com.swcampus.domain.auth.exception.InvalidCredentialsException;
 import com.swcampus.domain.auth.exception.InvalidPasswordException;
 import com.swcampus.domain.auth.exception.InvalidTokenException;
 import com.swcampus.domain.auth.exception.MailSendException;
@@ -72,6 +73,13 @@ public class GlobalExceptionHandler {
         log.warn("비밀번호 정책 위반: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidCredentialsException(InvalidCredentialsException e) {
+        log.warn("로그인 실패: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
     }
 
     // === Validation 예외 ===

--- a/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerEmailTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerEmailTest.java
@@ -55,6 +55,12 @@ class AuthControllerEmailTest {
     @MockitoBean
     private EmailService emailService;
 
+    @MockitoBean
+    private com.swcampus.domain.auth.TokenProvider tokenProvider;
+
+    @MockitoBean
+    private com.swcampus.api.config.CookieUtil cookieUtil;
+
     @Nested
     @DisplayName("POST /api/v1/auth/email/send - 인증 메일 발송")
     class SendVerificationEmail {

--- a/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerLoginTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerLoginTest.java
@@ -1,0 +1,231 @@
+package com.swcampus.api.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.swcampus.api.auth.request.LoginRequest;
+import com.swcampus.api.config.CookieUtil;
+import com.swcampus.api.config.SecurityConfig;
+import com.swcampus.api.exception.GlobalExceptionHandler;
+import com.swcampus.domain.auth.AuthService;
+import com.swcampus.domain.auth.EmailService;
+import com.swcampus.domain.auth.LoginResult;
+import com.swcampus.domain.auth.TokenProvider;
+import com.swcampus.domain.auth.exception.InvalidCredentialsException;
+import com.swcampus.domain.member.Member;
+import com.swcampus.domain.member.Role;
+import com.swcampus.domain.organization.ApprovalStatus;
+import com.swcampus.domain.organization.Organization;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test")
+@DisplayName("AuthController - 로그인/로그아웃 테스트")
+class AuthControllerLoginTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private CookieUtil cookieUtil;
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/login")
+    class Login {
+
+        @Test
+        @DisplayName("일반 회원 로그인 성공")
+        void loginUser() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("user@example.com", "Password1!");
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(1L);
+            when(member.getEmail()).thenReturn("user@example.com");
+            when(member.getName()).thenReturn("홍길동");
+            when(member.getNickname()).thenReturn("길동이");
+            when(member.getRole()).thenReturn(Role.USER);
+
+            LoginResult result = new LoginResult("access-token", "refresh-token", member);
+            when(authService.login(request.getEmail(), request.getPassword())).thenReturn(result);
+
+            when(tokenProvider.getAccessTokenValidity()).thenReturn(3600L);
+            when(tokenProvider.getRefreshTokenValidity()).thenReturn(86400L);
+
+            when(cookieUtil.createAccessTokenCookie("access-token", 3600L))
+                    .thenReturn(ResponseCookie.from("accessToken", "access-token").build());
+            when(cookieUtil.createRefreshTokenCookie("refresh-token", 86400L))
+                    .thenReturn(ResponseCookie.from("refreshToken", "refresh-token").build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"))
+                    .andExpect(jsonPath("$.userId").value(1))
+                    .andExpect(jsonPath("$.email").value("user@example.com"))
+                    .andExpect(jsonPath("$.name").value("홍길동"))
+                    .andExpect(jsonPath("$.role").value("USER"))
+                    .andExpect(jsonPath("$.organizationId").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("기관 회원 로그인 성공 - Organization 정보 포함")
+        void loginOrganization() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("org@example.com", "Password1!");
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(1L);
+            when(member.getEmail()).thenReturn("org@example.com");
+            when(member.getName()).thenReturn("김기관");
+            when(member.getNickname()).thenReturn("기관담당자");
+            when(member.getRole()).thenReturn(Role.ORGANIZATION);
+
+            Organization organization = mock(Organization.class);
+            when(organization.getId()).thenReturn(10L);
+            when(organization.getName()).thenReturn("테스트교육기관");
+            when(organization.getApprovalStatus()).thenReturn(ApprovalStatus.PENDING);
+
+            LoginResult result = new LoginResult("access-token", "refresh-token", member, organization);
+            when(authService.login(request.getEmail(), request.getPassword())).thenReturn(result);
+
+            when(tokenProvider.getAccessTokenValidity()).thenReturn(3600L);
+            when(tokenProvider.getRefreshTokenValidity()).thenReturn(86400L);
+
+            when(cookieUtil.createAccessTokenCookie("access-token", 3600L))
+                    .thenReturn(ResponseCookie.from("accessToken", "access-token").build());
+            when(cookieUtil.createRefreshTokenCookie("refresh-token", 86400L))
+                    .thenReturn(ResponseCookie.from("refreshToken", "refresh-token").build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.userId").value(1))
+                    .andExpect(jsonPath("$.role").value("ORGANIZATION"))
+                    .andExpect(jsonPath("$.organizationId").value(10))
+                    .andExpect(jsonPath("$.organizationName").value("테스트교육기관"))
+                    .andExpect(jsonPath("$.approvalStatus").value("PENDING"));
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 잘못된 자격 증명")
+        void loginFailed() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("user@example.com", "wrongPassword");
+            when(authService.login(request.getEmail(), request.getPassword()))
+                    .thenThrow(new InvalidCredentialsException());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 이메일 형식 오류")
+        void loginInvalidEmail() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("invalid-email", "Password1!");
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("로그인 실패 - 비밀번호 누락")
+        void loginMissingPassword() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("user@example.com", "");
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/logout")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃 성공")
+        void logout() throws Exception {
+            // given
+            when(tokenProvider.validateToken("valid-token")).thenReturn(true);
+            when(tokenProvider.getMemberId("valid-token")).thenReturn(1L);
+            when(cookieUtil.deleteAccessTokenCookie())
+                    .thenReturn(ResponseCookie.from("accessToken", "").maxAge(0).build());
+            when(cookieUtil.deleteRefreshTokenCookie())
+                    .thenReturn(ResponseCookie.from("refreshToken", "").maxAge(0).build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/logout")
+                            .cookie(new Cookie("accessToken", "valid-token")))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"));
+
+            verify(authService).logout(1L);
+        }
+
+        @Test
+        @DisplayName("로그아웃 성공 - 토큰 없이도 성공")
+        void logoutWithoutToken() throws Exception {
+            // given
+            when(cookieUtil.deleteAccessTokenCookie())
+                    .thenReturn(ResponseCookie.from("accessToken", "").maxAge(0).build());
+            when(cookieUtil.deleteRefreshTokenCookie())
+                    .thenReturn(ResponseCookie.from("refreshToken", "").maxAge(0).build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/logout"))
+                    .andExpect(status().isOk());
+        }
+    }
+}

--- a/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerSignupTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerSignupTest.java
@@ -53,6 +53,12 @@ class AuthControllerSignupTest {
     @MockitoBean
     private EmailService emailService;
 
+    @MockitoBean
+    private com.swcampus.domain.auth.TokenProvider tokenProvider;
+
+    @MockitoBean
+    private com.swcampus.api.config.CookieUtil cookieUtil;
+
     @Nested
     @DisplayName("POST /api/v1/auth/signup - 회원가입")
     class Signup {

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/auth/LoginResult.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/auth/LoginResult.java
@@ -1,0 +1,24 @@
+package com.swcampus.domain.auth;
+
+import com.swcampus.domain.member.Member;
+import com.swcampus.domain.organization.Organization;
+import lombok.Getter;
+
+@Getter
+public class LoginResult {
+    private final String accessToken;
+    private final String refreshToken;
+    private final Member member;
+    private final Organization organization;
+
+    public LoginResult(String accessToken, String refreshToken, Member member) {
+        this(accessToken, refreshToken, member, null);
+    }
+
+    public LoginResult(String accessToken, String refreshToken, Member member, Organization organization) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.member = member;
+        this.organization = organization;
+    }
+}

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/auth/exception/InvalidCredentialsException.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/auth/exception/InvalidCredentialsException.java
@@ -1,0 +1,8 @@
+package com.swcampus.domain.auth.exception;
+
+public class InvalidCredentialsException extends RuntimeException {
+
+    public InvalidCredentialsException() {
+        super("이메일 또는 비밀번호가 일치하지 않습니다");
+    }
+}

--- a/sw-campus-domain/src/test/java/com/swcampus/domain/auth/AuthServiceLoginTest.java
+++ b/sw-campus-domain/src/test/java/com/swcampus/domain/auth/AuthServiceLoginTest.java
@@ -1,0 +1,199 @@
+package com.swcampus.domain.auth;
+
+import com.swcampus.domain.auth.exception.InvalidCredentialsException;
+import com.swcampus.domain.member.Member;
+import com.swcampus.domain.member.MemberRepository;
+import com.swcampus.domain.member.Role;
+import com.swcampus.domain.organization.ApprovalStatus;
+import com.swcampus.domain.organization.Organization;
+import com.swcampus.domain.organization.OrganizationRepository;
+import com.swcampus.domain.storage.FileStorageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService - 로그인/로그아웃 테스트")
+class AuthServiceLoginTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private PasswordValidator passwordValidator;
+
+    @Mock
+    private FileStorageService fileStorageService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("login")
+    class Login {
+
+        @Test
+        @DisplayName("일반 회원 로그인에 성공한다")
+        void loginUser() {
+            // given
+            String email = "user@example.com";
+            String password = "Password1!";
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(1L);
+            when(member.getEmail()).thenReturn(email);
+            when(member.getPassword()).thenReturn("encodedPassword");
+            when(member.getRole()).thenReturn(Role.USER);
+
+            when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+            when(passwordEncoder.matches(password, "encodedPassword")).thenReturn(true);
+            when(tokenProvider.createAccessToken(1L, email, Role.USER)).thenReturn("access-token");
+            when(tokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
+            when(tokenProvider.getRefreshTokenValidity()).thenReturn(86400L);
+
+            // when
+            LoginResult result = authService.login(email, password);
+
+            // then
+            assertThat(result.getAccessToken()).isEqualTo("access-token");
+            assertThat(result.getRefreshToken()).isEqualTo("refresh-token");
+            assertThat(result.getMember()).isEqualTo(member);
+            assertThat(result.getOrganization()).isNull();
+        }
+
+        @Test
+        @DisplayName("기관 회원 로그인에 성공하면 Organization 정보도 포함된다")
+        void loginOrganization() {
+            // given
+            String email = "org@example.com";
+            String password = "Password1!";
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(1L);
+            when(member.getEmail()).thenReturn(email);
+            when(member.getPassword()).thenReturn("encodedPassword");
+            when(member.getRole()).thenReturn(Role.ORGANIZATION);
+            when(member.getOrgId()).thenReturn(10L);
+
+            Organization organization = mock(Organization.class);
+            when(organization.getName()).thenReturn("테스트기관");
+            when(organization.getApprovalStatus()).thenReturn(ApprovalStatus.PENDING);
+
+            when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+            when(passwordEncoder.matches(password, "encodedPassword")).thenReturn(true);
+            when(organizationRepository.findById(10L)).thenReturn(Optional.of(organization));
+            when(tokenProvider.createAccessToken(1L, email, Role.ORGANIZATION)).thenReturn("access-token");
+            when(tokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
+            when(tokenProvider.getRefreshTokenValidity()).thenReturn(86400L);
+
+            // when
+            LoginResult result = authService.login(email, password);
+
+            // then
+            assertThat(result.getAccessToken()).isEqualTo("access-token");
+            assertThat(result.getOrganization()).isNotNull();
+            assertThat(result.getOrganization().getName()).isEqualTo("테스트기관");
+            assertThat(result.getOrganization().getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 로그인 시 실패한다")
+        void loginEmailNotFound() {
+            // given
+            when(memberRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.login("unknown@example.com", "password"))
+                    .isInstanceOf(InvalidCredentialsException.class)
+                    .hasMessage("이메일 또는 비밀번호가 일치하지 않습니다");
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 시 로그인 실패한다")
+        void loginWrongPassword() {
+            // given
+            Member member = mock(Member.class);
+            when(member.getPassword()).thenReturn("encodedPassword");
+            when(memberRepository.findByEmail("user@example.com")).thenReturn(Optional.of(member));
+            when(passwordEncoder.matches("wrongPassword", "encodedPassword")).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.login("user@example.com", "wrongPassword"))
+                    .isInstanceOf(InvalidCredentialsException.class);
+        }
+
+        @Test
+        @DisplayName("로그인 시 기존 Refresh Token이 삭제된다 (동시 로그인 제한)")
+        void loginDeletesExistingRefreshToken() {
+            // given
+            String email = "user@example.com";
+            String password = "Password1!";
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(1L);
+            when(member.getEmail()).thenReturn(email);
+            when(member.getPassword()).thenReturn("encodedPassword");
+            when(member.getRole()).thenReturn(Role.USER);
+
+            when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+            when(passwordEncoder.matches(password, "encodedPassword")).thenReturn(true);
+            when(tokenProvider.createAccessToken(any(), any(), any())).thenReturn("access-token");
+            when(tokenProvider.createRefreshToken(any())).thenReturn("refresh-token");
+            when(tokenProvider.getRefreshTokenValidity()).thenReturn(86400L);
+
+            // when
+            authService.login(email, password);
+
+            // then
+            verify(refreshTokenRepository).deleteByMemberId(1L);
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("logout")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃 시 Refresh Token이 삭제된다")
+        void logout() {
+            // given
+            Long memberId = 1L;
+
+            // when
+            authService.logout(memberId);
+
+            // then
+            verify(refreshTokenRepository).deleteByMemberId(memberId);
+        }
+    }
+}

--- a/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/auth/RefreshTokenJpaRepository.java
+++ b/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/auth/RefreshTokenJpaRepository.java
@@ -1,11 +1,17 @@
 package com.swcampus.infra.postgres.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenEntity, Long> {
     Optional<RefreshTokenEntity> findByMemberId(Long memberId);
     Optional<RefreshTokenEntity> findByToken(String token);
-    void deleteByMemberId(Long memberId);
+    
+    @Modifying
+    @Query("DELETE FROM RefreshTokenEntity r WHERE r.memberId = :memberId")
+    void deleteByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 📋 PR 요약

- POST /api/v1/auth/login 엔드포인트 추가
- POST /api/v1/auth/logout 엔드포인트 추가
- JWT Access/Refresh Token Cookie 발급
- Refresh Token DB 저장 및 동시 로그인 제한
- InvalidCredentialsException 예외 처리 (401)
- ORGANIZATION 역할 로그인 시 approvalStatus 응답 포함

## 🔗 관련 이슈

closes #34 

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
