### PR TITLE
feat: 토큰 갱신 API 구현

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/auth/AuthController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/auth/AuthController.java
@@ -15,6 +15,7 @@ import com.swcampus.domain.auth.EmailService;
 import com.swcampus.domain.auth.LoginResult;
 import com.swcampus.domain.auth.OrganizationSignupResult;
 import com.swcampus.domain.auth.TokenProvider;
+import com.swcampus.domain.auth.exception.InvalidTokenException;
 import com.swcampus.domain.member.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -126,6 +127,24 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, deleteAccessCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, deleteRefreshCookie.toString())
+                .build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Void> refresh(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new InvalidTokenException();
+        }
+
+        String newAccessToken = authService.refresh(refreshToken);
+
+        ResponseCookie accessTokenCookie = cookieUtil.createAccessTokenCookie(
+                newAccessToken, tokenProvider.getAccessTokenValidity());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
                 .build();
     }
 }

--- a/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerRefreshTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthControllerRefreshTest.java
@@ -1,0 +1,113 @@
+package com.swcampus.api.auth;
+
+import com.swcampus.api.config.CookieUtil;
+import com.swcampus.api.config.SecurityConfig;
+import com.swcampus.api.exception.GlobalExceptionHandler;
+import com.swcampus.domain.auth.AuthService;
+import com.swcampus.domain.auth.EmailService;
+import com.swcampus.domain.auth.TokenProvider;
+import com.swcampus.domain.auth.exception.InvalidTokenException;
+import com.swcampus.domain.auth.exception.TokenExpiredException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test")
+@DisplayName("AuthController - 토큰 갱신 테스트")
+class AuthControllerRefreshTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private EmailService emailService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private CookieUtil cookieUtil;
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/refresh")
+    class Refresh {
+
+        @Test
+        @DisplayName("토큰 갱신 성공 시 새 Access Token 쿠키를 반환한다")
+        void refresh_success() throws Exception {
+            // given
+            String refreshToken = "valid-refresh-token";
+            String newAccessToken = "new-access-token";
+
+            when(authService.refresh(refreshToken)).thenReturn(newAccessToken);
+            when(tokenProvider.getAccessTokenValidity()).thenReturn(3600L);
+            when(cookieUtil.createAccessTokenCookie(newAccessToken, 3600L))
+                    .thenReturn(ResponseCookie.from("accessToken", newAccessToken).build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/refresh")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("Set-Cookie"));
+        }
+
+        @Test
+        @DisplayName("Refresh Token이 없으면 401 반환")
+        void refresh_noToken() throws Exception {
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/refresh"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 Refresh Token이면 401 반환")
+        void refresh_invalidToken() throws Exception {
+            // given
+            String refreshToken = "invalid-token";
+            when(authService.refresh(refreshToken)).thenThrow(new InvalidTokenException());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/refresh")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("만료된 Refresh Token이면 401 반환")
+        void refresh_expiredToken() throws Exception {
+            // given
+            String refreshToken = "expired-token";
+            when(authService.refresh(refreshToken)).thenThrow(new TokenExpiredException());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/auth/refresh")
+                            .cookie(new Cookie("refreshToken", refreshToken)))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/sw-campus-domain/src/test/java/com/swcampus/domain/auth/AuthServiceRefreshTest.java
+++ b/sw-campus-domain/src/test/java/com/swcampus/domain/auth/AuthServiceRefreshTest.java
@@ -1,0 +1,200 @@
+package com.swcampus.domain.auth;
+
+import com.swcampus.domain.auth.exception.InvalidTokenException;
+import com.swcampus.domain.auth.exception.TokenExpiredException;
+import com.swcampus.domain.member.Member;
+import com.swcampus.domain.member.MemberRepository;
+import com.swcampus.domain.member.Role;
+import com.swcampus.domain.organization.OrganizationRepository;
+import com.swcampus.domain.storage.FileStorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService - 토큰 갱신 테스트")
+class AuthServiceRefreshTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private PasswordValidator passwordValidator;
+
+    @Mock
+    private FileStorageService fileStorageService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+                memberRepository,
+                organizationRepository,
+                emailVerificationRepository,
+                refreshTokenRepository,
+                passwordEncoder,
+                passwordValidator,
+                fileStorageService,
+                tokenProvider
+        );
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 성공")
+    class RefreshSuccess {
+
+        @Test
+        @DisplayName("유효한 Refresh Token으로 새 Access Token을 발급받는다")
+        void refresh() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long memberId = 1L;
+
+            RefreshToken storedToken = mock(RefreshToken.class);
+            when(storedToken.getToken()).thenReturn(refreshToken);
+            when(storedToken.isExpired()).thenReturn(false);
+
+            Member member = mock(Member.class);
+            when(member.getId()).thenReturn(memberId);
+            when(member.getEmail()).thenReturn("user@example.com");
+            when(member.getRole()).thenReturn(Role.USER);
+
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(tokenProvider.getMemberId(refreshToken)).thenReturn(memberId);
+            when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.of(storedToken));
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(tokenProvider.createAccessToken(memberId, "user@example.com", Role.USER))
+                    .thenReturn("new-access-token");
+
+            // when
+            String newAccessToken = authService.refresh(refreshToken);
+
+            // then
+            assertThat(newAccessToken).isEqualTo("new-access-token");
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 실패")
+    class RefreshFailure {
+
+        @Test
+        @DisplayName("유효하지 않은 Refresh Token으로 갱신 시 실패한다")
+        void refresh_invalidToken() {
+            // given
+            String refreshToken = "invalid-token";
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(refreshToken))
+                    .isInstanceOf(InvalidTokenException.class);
+        }
+
+        @Test
+        @DisplayName("DB에 없는 Refresh Token으로 갱신 시 실패한다")
+        void refresh_tokenNotInDb() {
+            // given
+            String refreshToken = "valid-but-not-in-db";
+            Long memberId = 1L;
+
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(tokenProvider.getMemberId(refreshToken)).thenReturn(memberId);
+            when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(refreshToken))
+                    .isInstanceOf(InvalidTokenException.class);
+        }
+
+        @Test
+        @DisplayName("토큰 값이 일치하지 않으면 갱신 실패 (다른 기기에서 로그인)")
+        void refresh_tokenMismatch() {
+            // given
+            String refreshToken = "old-refresh-token";
+            Long memberId = 1L;
+
+            RefreshToken storedToken = mock(RefreshToken.class);
+            when(storedToken.getToken()).thenReturn("new-refresh-token");  // 다른 토큰
+
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(tokenProvider.getMemberId(refreshToken)).thenReturn(memberId);
+            when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.of(storedToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(refreshToken))
+                    .isInstanceOf(InvalidTokenException.class);
+        }
+
+        @Test
+        @DisplayName("만료된 Refresh Token으로 갱신 시 실패하고 토큰이 삭제된다")
+        void refresh_expiredToken() {
+            // given
+            String refreshToken = "expired-refresh-token";
+            Long memberId = 1L;
+
+            RefreshToken storedToken = mock(RefreshToken.class);
+            when(storedToken.getToken()).thenReturn(refreshToken);
+            when(storedToken.isExpired()).thenReturn(true);
+
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(tokenProvider.getMemberId(refreshToken)).thenReturn(memberId);
+            when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.of(storedToken));
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(refreshToken))
+                    .isInstanceOf(TokenExpiredException.class);
+
+            verify(refreshTokenRepository).deleteByMemberId(memberId);
+        }
+
+        @Test
+        @DisplayName("회원이 존재하지 않으면 갱신 실패한다")
+        void refresh_memberNotFound() {
+            // given
+            String refreshToken = "valid-refresh-token";
+            Long memberId = 1L;
+
+            RefreshToken storedToken = mock(RefreshToken.class);
+            when(storedToken.getToken()).thenReturn(refreshToken);
+            when(storedToken.isExpired()).thenReturn(false);
+
+            when(tokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(tokenProvider.getMemberId(refreshToken)).thenReturn(memberId);
+            when(refreshTokenRepository.findByMemberId(memberId)).thenReturn(Optional.of(storedToken));
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.refresh(refreshToken))
+                    .isInstanceOf(InvalidTokenException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 📋 PR 요약

- AuthService에 refresh() 메서드 추가
- POST /api/v1/auth/refresh 엔드포인트 구현
- Refresh Token 유효성 검증 및 DB 일치 확인
- 만료된 토큰 자동 삭제 처리
- 단위 테스트 6개, 통합 테스트 4개 추가

## 🔗 관련 이슈

closes #38 

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
