### PR TITLE
fix(security): 닉네임 중복 검사 API 공개 접근 허용

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/config/SecurityConfig.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/organizations/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/banners/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/members/nickname/check").permitAll()
                         // 관리자 API (인증 필요, 추후 ROLE_ADMIN 추가 가능)
                         .requestMatchers("/api/v1/admin/**").authenticated()
                         // 나머지는 인증 필요


### PR DESCRIPTION
## Summary
- 닉네임 중복 검사 API (`GET /api/v1/members/nickname/check`)를 인증 없이 접근 가능하도록 SecurityConfig에 추가
- 회원가입 시 비로그인 상태에서 닉네임 중복 확인이 필요하기 때문

## Changes
- `SecurityConfig.java`: `/api/v1/members/nickname/check` 엔드포인트를 `permitAll()` 목록에 추가

## Test plan
- [ ] 비로그인 상태에서 닉네임 중복 검사 API 호출 테스트
- [ ] 회원가입 플로우에서 닉네임 중복 검사 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)