### PR TITLE
fix(test): 테스트 코드와 서비스 코드 간 불일치 수정

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/response/AdminCertificateResponse.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/response/AdminCertificateResponse.java
@@ -13,8 +13,8 @@ public record AdminCertificateResponse(
     @Schema(description = "강의명", example = "웹 개발 부트캠프")
     String lectureName,
 
-    @Schema(description = "수료증 이미지 S3 Key", example = "certificates/2024/01/01/uuid.jpg")
-    String imageKey,
+    @Schema(description = "수료증 이미지 URL", example = "https://s3.../certificates/2024/01/01/uuid.jpg")
+    String imageUrl,
 
     @Schema(description = "승인 상태 (PENDING, APPROVED, REJECTED)", example = "PENDING")
     String approvalStatus,

--- a/sw-campus-api/src/main/java/com/swcampus/api/certificate/response/CertificateCheckResponse.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/certificate/response/CertificateCheckResponse.java
@@ -13,8 +13,8 @@ public record CertificateCheckResponse(
     @Schema(description = "수료증 ID", example = "1")
     Long certificateId,
 
-    @Schema(description = "수료증 이미지 S3 Key", example = "certificates/2024/01/01/uuid.jpg")
-    String imageKey,
+    @Schema(description = "수료증 이미지 URL", example = "https://s3.../certificates/2024/01/01/uuid.jpg")
+    String imageUrl,
 
     @Schema(description = "승인 상태 (PENDING, APPROVED, REJECTED)", example = "APPROVED")
     String approvalStatus,
@@ -22,19 +22,19 @@ public record CertificateCheckResponse(
     @Schema(description = "인증 일시", example = "2025-01-15T10:30:00")
     String certifiedAt
 ) {
-    private static final DateTimeFormatter FORMATTER = 
+    private static final DateTimeFormatter FORMATTER =
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     public static CertificateCheckResponse notCertified() {
         return new CertificateCheckResponse(false, null, null, null, null);
     }
 
-    public static CertificateCheckResponse certified(Long id, String imageKey,
+    public static CertificateCheckResponse certified(Long id, String imageUrl,
                                                       String status, LocalDateTime certifiedAt) {
         return new CertificateCheckResponse(
             true,
             id,
-            imageKey,
+            imageUrl,
             status,
             certifiedAt != null ? certifiedAt.format(FORMATTER) : null
         );

--- a/sw-campus-api/src/main/java/com/swcampus/api/certificate/response/CertificateVerifyResponse.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/certificate/response/CertificateVerifyResponse.java
@@ -10,8 +10,8 @@ public record CertificateVerifyResponse(
     @Schema(description = "강의 ID", example = "10")
     Long lectureId,
 
-    @Schema(description = "수료증 이미지 S3 Key", example = "certificates/2024/01/01/uuid.jpg")
-    String imageKey,
+    @Schema(description = "수료증 이미지 URL", example = "https://s3.../certificates/2024/01/01/uuid.jpg")
+    String imageUrl,
 
     @Schema(description = "승인 상태 (PENDING)", example = "PENDING")
     String approvalStatus,
@@ -20,11 +20,11 @@ public record CertificateVerifyResponse(
     String message
 ) {
     public static CertificateVerifyResponse of(Long certificateId, Long lectureId,
-                                                String imageKey, String approvalStatus) {
+                                                String imageUrl, String approvalStatus) {
         return new CertificateVerifyResponse(
             certificateId,
             lectureId,
-            imageKey,
+            imageUrl,
             approvalStatus,
             "수료증 인증이 완료되었습니다. 관리자 승인 후 후기 작성이 가능합니다."
         );

--- a/sw-campus-api/src/test/java/com/swcampus/api/certificate/CertificateIntegrationTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/certificate/CertificateIntegrationTest.java
@@ -135,8 +135,8 @@ class CertificateIntegrationTest {
             given(ocrClient.extractText(any(byte[].class), anyString()))
                     .willReturn(List.of("수료증", "Spring Boot 실전 강의", "수료를 증명합니다"));
             
-            // Mock 설정: S3 업로드 성공
-            given(fileStorageService.upload(any(byte[].class), eq("certificates"), anyString(), anyString()))
+            // Mock 설정: S3 Private Bucket 업로드 성공
+            given(fileStorageService.uploadPrivate(any(byte[].class), eq("certificates"), anyString(), anyString()))
                     .willReturn("https://s3.example.com/certificate/test.jpg");
 
             MockMultipartFile imageFile = new MockMultipartFile(
@@ -187,7 +187,7 @@ class CertificateIntegrationTest {
             // 중복 인증 시도
             given(ocrClient.extractText(any(byte[].class), anyString()))
                     .willReturn(List.of("수료증", "Spring Boot 실전 강의"));
-            given(fileStorageService.upload(any(byte[].class), eq("certificates"), anyString(), anyString()))
+            given(fileStorageService.uploadPrivate(any(byte[].class), eq("certificates"), anyString(), anyString()))
                     .willReturn("https://s3.example.com/new-certificate.jpg");
 
             MockMultipartFile imageFile = new MockMultipartFile(
@@ -282,7 +282,7 @@ class CertificateIntegrationTest {
             given(ocrClient.extractText(any(byte[].class), anyString()))
                     .willReturn(List.of("수료증", "SpringBoot실전강의", "2024년 수료"));
             
-            given(fileStorageService.upload(any(byte[].class), eq("certificates"), anyString(), anyString()))
+            given(fileStorageService.uploadPrivate(any(byte[].class), eq("certificates"), anyString(), anyString()))
                     .willReturn("https://s3.example.com/certificate/test.jpg");
 
             MockMultipartFile imageFile = new MockMultipartFile(
@@ -318,7 +318,7 @@ class CertificateIntegrationTest {
                             "수료를 증명합니다"
                     ));
             
-            given(fileStorageService.upload(any(byte[].class), eq("certificates"), anyString(), anyString()))
+            given(fileStorageService.uploadPrivate(any(byte[].class), eq("certificates"), anyString(), anyString()))
                     .willReturn("https://s3.example.com/certificate/test.jpg");
 
             MockMultipartFile imageFile = new MockMultipartFile(

--- a/sw-campus-domain/src/test/java/com/swcampus/domain/lecture/LectureServiceTest.java
+++ b/sw-campus-domain/src/test/java/com/swcampus/domain/lecture/LectureServiceTest.java
@@ -1,6 +1,5 @@
 package com.swcampus.domain.lecture;
 
-import com.swcampus.domain.lecture.exception.LectureNotModifiableException;
 import com.swcampus.domain.storage.FileStorageService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -63,8 +62,8 @@ class LectureServiceTest {
         }
 
         @Test
-        @DisplayName("승인된 강의 수정 시 예외 발생")
-        void modifyLecture_approved_throwsException() {
+        @DisplayName("승인된 강의 수정 성공 및 상태 유지(APPROVED)")
+        void modifyLecture_approved_success() {
             // given
             Long lectureId = 1L;
             Long orgId = 1L;
@@ -74,17 +73,25 @@ class LectureServiceTest {
                     .lectureAuthStatus(LectureAuthStatus.APPROVED)
                     .build();
 
+            Lecture updateParams = Lecture.builder()
+                    .lectureName("수정된 강의")
+                    .build();
+
             given(lectureRepository.findById(lectureId))
                     .willReturn(Optional.of(existingLecture));
+            given(lectureRepository.save(any(Lecture.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
 
-            // when & then
-            assertThatThrownBy(() -> lectureService.modifyLecture(lectureId, orgId, Lecture.builder().build(), null, null, null, Collections.emptyList()))
-                    .isInstanceOf(LectureNotModifiableException.class);
+            // when
+            Lecture result = lectureService.modifyLecture(lectureId, orgId, updateParams, null, null, null, Collections.emptyList());
+
+            // then
+            assertThat(result.getLectureAuthStatus()).isEqualTo(LectureAuthStatus.APPROVED);
         }
-        
+
         @Test
-        @DisplayName("대기중인 강의 수정 시 예외 발생")
-        void modifyLecture_pending_throwsException() {
+        @DisplayName("대기중인 강의 수정 성공 및 상태 유지(PENDING)")
+        void modifyLecture_pending_success() {
             // given
             Long lectureId = 1L;
             Long orgId = 1L;
@@ -94,12 +101,20 @@ class LectureServiceTest {
                     .lectureAuthStatus(LectureAuthStatus.PENDING)
                     .build();
 
+            Lecture updateParams = Lecture.builder()
+                    .lectureName("수정된 강의")
+                    .build();
+
             given(lectureRepository.findById(lectureId))
                     .willReturn(Optional.of(existingLecture));
+            given(lectureRepository.save(any(Lecture.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
 
-            // when & then
-            assertThatThrownBy(() -> lectureService.modifyLecture(lectureId, orgId, Lecture.builder().build(), null, null, null, Collections.emptyList()))
-                    .isInstanceOf(LectureNotModifiableException.class);
+            // when
+            Lecture result = lectureService.modifyLecture(lectureId, orgId, updateParams, null, null, null, Collections.emptyList());
+
+            // then
+            assertThat(result.getLectureAuthStatus()).isEqualTo(LectureAuthStatus.PENDING);
         }
 
         @Test

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/organization/OrganizationRepositoryTest.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/organization/OrganizationRepositoryTest.java
@@ -40,7 +40,7 @@ class OrganizationRepositoryTest {
         assertThat(found.get().getName()).isEqualTo("소프트웨어 캠퍼스");
         assertThat(found.get().getDescription()).isEqualTo("IT 교육 전문 기관");
         assertThat(found.get().getUserId()).isEqualTo(1L);
-        assertThat(found.get().getCertificateUrl()).isEqualTo("https://s3.../cert.jpg");
+        assertThat(found.get().getCertificateKey()).isEqualTo("https://s3.../cert.jpg");
         assertThat(found.get().getApprovalStatus()).isEqualTo(ApprovalStatus.PENDING);
     }
 

--- a/sw-campus-infra/s3/src/test/java/com/swcampus/infra/s3/S3PresignedUrlServiceTest.java
+++ b/sw-campus-infra/s3/src/test/java/com/swcampus/infra/s3/S3PresignedUrlServiceTest.java
@@ -1,5 +1,6 @@
 package com.swcampus.infra.s3;
 
+import com.swcampus.domain.member.Role;
 import com.swcampus.domain.storage.PresignedUrlService.PresignedUploadUrl;
 import com.swcampus.domain.storage.PresignedUrlService.PresignedUrl;
 import com.swcampus.domain.storage.exception.InvalidStorageCategoryException;
@@ -210,7 +211,7 @@ class S3PresignedUrlServiceTest {
             String contentType = "image/jpeg";
 
             // when
-            PresignedUploadUrl result = service.getPresignedUploadUrl(category, fileName, contentType);
+            PresignedUploadUrl result = service.getPresignedUploadUrl(category, fileName, contentType, Role.ORGANIZATION);
 
             // then
             assertThat(result.uploadUrl()).isNotNull();
@@ -223,7 +224,7 @@ class S3PresignedUrlServiceTest {
         @DisplayName("certificates 카테고리로 업로드 URL을 발급받는다")
         void certificates_success() {
             // when
-            PresignedUploadUrl result = service.getPresignedUploadUrl("certificates", "cert.pdf", "application/pdf");
+            PresignedUploadUrl result = service.getPresignedUploadUrl("certificates", "cert.pdf", "application/pdf", Role.USER);
 
             // then
             assertThat(result.key()).startsWith("certificates/");
@@ -233,7 +234,7 @@ class S3PresignedUrlServiceTest {
         @DisplayName("employment-certificates 카테고리로 업로드 URL을 발급받는다")
         void employmentCertificates_success() {
             // when
-            PresignedUploadUrl result = service.getPresignedUploadUrl("employment-certificates", "doc.pdf", "application/pdf");
+            PresignedUploadUrl result = service.getPresignedUploadUrl("employment-certificates", "doc.pdf", "application/pdf", Role.USER);
 
             // then
             assertThat(result.key()).startsWith("employment-certificates/");
@@ -243,7 +244,7 @@ class S3PresignedUrlServiceTest {
         @DisplayName("잘못된 카테고리는 예외가 발생한다")
         void invalidCategory_throwsException() {
             // when & then
-            assertThatThrownBy(() -> service.getPresignedUploadUrl("invalid-category", "test.jpg", "image/jpeg"))
+            assertThatThrownBy(() -> service.getPresignedUploadUrl("invalid-category", "test.jpg", "image/jpeg", Role.USER))
                     .isInstanceOf(InvalidStorageCategoryException.class);
         }
 
@@ -251,7 +252,7 @@ class S3PresignedUrlServiceTest {
         @DisplayName("생성된 key는 UUID를 포함한다")
         void generatedKey_containsUuid() {
             // when
-            PresignedUploadUrl result = service.getPresignedUploadUrl("lectures", "original-name.jpg", "image/jpeg");
+            PresignedUploadUrl result = service.getPresignedUploadUrl("lectures", "original-name.jpg", "image/jpeg", Role.ORGANIZATION);
 
             // then
             String key = result.key();


### PR DESCRIPTION
## Summary
- Certificate Response DTO 필드명 수정 (`imageKey` → `imageUrl`)으로 JSON 직렬화 불일치 해결
- 서비스 코드 변경사항을 반영하여 테스트 코드 동기화 (mock 메서드, 메서드 시그니처 등)
- 비즈니스 로직 변경 반영 (강의 수정 정책 변경)

## Changes
| 파일 | 수정 내용 |
|------|----------|
| `CertificateCheckResponse.java` | `imageKey` → `imageUrl` 필드명 변경 |
| `CertificateVerifyResponse.java` | `imageKey` → `imageUrl` 필드명 변경 |
| `AdminCertificateResponse.java` | `imageKey` → `imageUrl` 필드명 변경 |
| `CertificateIntegrationTest.java` | `upload()` → `uploadPrivate()` mock 수정 |
| `LectureServiceTest.java` | 승인/대기중 강의 수정 테스트를 성공 케이스로 변경 |
| `OrganizationRepositoryTest.java` | `getCertificateUrl()` → `getCertificateKey()` 수정 |
| `S3PresignedUrlServiceTest.java` | `getPresignedUploadUrl()`에 `Role` 파라미터 추가 |

## Test plan
- [x] `./gradlew test` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)