### PR TITLE
build: VSCode 멀티모듈 지원을 위한 eclipse 플러그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'java'
     id 'org.springframework.boot' apply false
     id 'io.spring.dependency-management' apply false
+    id 'eclipse'
+}
+
+// VSCode Java Extension 지원을 위한 Eclipse 프로젝트 파일 생성
+allprojects {
+    apply plugin: 'eclipse'
 }
 
 java {


### PR DESCRIPTION
## Summary
- VSCode Java Extension이 Gradle 멀티모듈 프로젝트의 모든 서브모듈을 인식할 수 있도록 eclipse 플러그인 추가
- `./gradlew eclipse` 명령으로 Eclipse 메타데이터 생성 가능
- IntelliJ 사용자에게는 영향 없음

## Test plan
- [ ] VSCode에서 `./gradlew eclipse` 실행 후 모듈 인식 확인
- [ ] `./gradlew build` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)