### PR TITLE
fix(organization): 기관 반려 시 Member 삭제 대신 상태만 변경

### DIFF
--- a/sw-campus-domain/src/test/java/com/swcampus/domain/organization/AdminOrganizationServiceTest.java
+++ b/sw-campus-domain/src/test/java/com/swcampus/domain/organization/AdminOrganizationServiceTest.java
@@ -103,7 +103,7 @@ class AdminOrganizationServiceTest {
     }
 
     @Test
-    @DisplayName("기관 반려 성공 - Member 삭제 및 관리자 연락처 반환")
+    @DisplayName("기관 반려 성공 - REJECTED 상태로 변경 및 관리자 연락처 반환")
     void rejectOrganization_Success() {
         // given
         Long orgId = 1L;
@@ -122,6 +122,7 @@ class AdminOrganizationServiceTest {
         assertThat(result.getMemberEmail()).isEqualTo("test@test.com");
         assertThat(result.getAdminEmail()).isEqualTo("admin@test.com");
         assertThat(result.getAdminPhone()).isEqualTo("010-9999-9999");
-        verify(memberRepository).deleteById(member.getId());
+        assertThat(organization.getApprovalStatus()).isEqualTo(ApprovalStatus.REJECTED);
+        verify(organizationRepository).save(organization);
     }
 }


### PR DESCRIPTION
## 📋 PR 요약

기관 반려 시 Member를 삭제하는 대신 Organization 상태만 REJECTED로 변경하도록 수정합니다.

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 추가해주세요 -->

## 📝 변경 사항

- 기관 반려 시 `memberRepository.deleteById()` 제거
- `organization.reject()` 호출하여 REJECTED 상태로 변경
- REJECTED 상태에서는 강의 생성 등 기능이 기존 로직에 의해 자동 제한됨
- Member 유지로 재신청 시 새로 가입할 필요 없음
- 관련 테스트 코드 수정

## 💬 리뷰어에게 (선택)

기존에는 반려 시 Member를 삭제했으나, Organization의 상태(REJECTED)만으로도 기능 제한이 충분히 동작합니다.
`OrganizationService.getApprovedOrganizationByUserId()`에서 APPROVED가 아니면 예외를 발생시키기 때문입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)