### PR TITLE
fix(test): 비밀번호 찾기 고도화에 따른 테스트 수정 및 빈 충돌 해결

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminBannerController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminBannerController.java
@@ -89,11 +89,11 @@ public class AdminBannerController {
         })
         @GetMapping
         public ResponseEntity<Page<AdminBannerResponse>> getBanners(
-                        @Parameter(description = "강의명 검색어") @RequestParam(required = false) String keyword,
-                        @Parameter(description = "기간 상태 (SCHEDULED, ACTIVE, ENDED)") @RequestParam(required = false) String periodStatus,
-                        @Parameter(description = "배너 타입 (BIG, MIDDLE, SMALL)") @RequestParam(required = false) BannerType type,
-                        @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
-                        @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size) {
+                        @Parameter(description = "강의명 검색어") @RequestParam(name = "keyword", required = false) String keyword,
+                        @Parameter(description = "기간 상태 (SCHEDULED, ACTIVE, ENDED)") @RequestParam(name = "periodStatus", required = false) String periodStatus,
+                        @Parameter(description = "배너 타입 (BIG, MIDDLE, SMALL)") @RequestParam(name = "type", required = false) BannerType type,
+                        @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(name = "page", defaultValue = "0") int page,
+                        @Parameter(description = "페이지 크기") @RequestParam(name = "size", defaultValue = "10") int size) {
                 Pageable pageable = PageRequest.of(page, size);
                 BannerPeriodStatus status = BannerPeriodStatus.fromString(periodStatus);
                 Page<BannerDetailsDto> bannerPage = adminBannerService.searchBanners(keyword, status, type, pageable);

--- a/sw-campus-api/src/main/java/com/swcampus/api/organization/OrganizationController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/organization/OrganizationController.java
@@ -46,7 +46,7 @@ public class OrganizationController {
                         @ApiResponse(responseCode = "200", description = "조회 성공")
         })
         public ResponseEntity<List<OrganizationSummaryResponse>> getOrganizationList(
-                        @Parameter(description = "검색 키워드 (기관명)", example = "패스트캠퍼스") @RequestParam(required = false) String keyword) {
+                        @Parameter(description = "검색 키워드 (기관명)", example = "패스트캠퍼스") @RequestParam(name = "keyword", required = false) String keyword) {
 
                 List<Organization> result = organizationService.getOrganizationList(keyword);
 

--- a/sw-campus-api/src/main/java/com/swcampus/api/teacher/TeacherController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/teacher/TeacherController.java
@@ -42,7 +42,7 @@ public class TeacherController {
     @GetMapping
     public List<TeacherResponse> searchTeachers(
             @Parameter(description = "강사 이름", example = "김철수")
-            @RequestParam(required = false, defaultValue = "") String name) {
+            @RequestParam(name = "name", required = false, defaultValue = "") String name) {
         return teacherService.searchTeachers(name).stream()
                 .map(TeacherResponse::from)
                 .toList();

--- a/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthIntegrationTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/auth/AuthIntegrationTest.java
@@ -313,8 +313,8 @@ class AuthIntegrationTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 정보로 임시 비밀번호 요청해도 동일 응답 (보안)")
-        void requestTemporaryPasswordForNonExistent_sameResponse() throws Exception {
+        @DisplayName("존재하지 않는 정보로 임시 비밀번호 요청 시 400 반환")
+        void requestTemporaryPasswordForNonExistent_returns400() throws Exception {
             TemporaryPasswordRequest request = new TemporaryPasswordRequest(
                     "존재하지않음", "010-9999-9999", "nonexistent@example.com"
             );
@@ -322,8 +322,7 @@ class AuthIntegrationTest {
             mockMvc.perform(post("/api/v1/auth/password/temporary")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.message").value("임시 비밀번호가 이메일로 발송되었습니다"));
+                    .andExpect(status().isBadRequest());
         }
 
         @Test

--- a/sw-campus-api/src/test/java/com/swcampus/api/mypage/MypageControllerTest.java
+++ b/sw-campus-api/src/test/java/com/swcampus/api/mypage/MypageControllerTest.java
@@ -356,7 +356,7 @@ class MypageControllerTest {
 
         Organization org = Organization.of(100L, 1L, "Test Org", "Desc", ApprovalStatus.APPROVED, "cert.jpg", null, null, null, null, null, null, null, LocalDateTime.now(), LocalDateTime.now());
 
-        given(organizationService.getApprovedOrganizationByUserId(1L)).willReturn(org);
+        given(organizationService.getOrganizationByUserId(1L)).willReturn(org);
 
         MockMultipartFile file = new MockMultipartFile("businessRegistration", "cert.jpg", "image/jpeg", "content".getBytes());
         MockMultipartFile organizationNamePart = new MockMultipartFile("organizationName", "", "text/plain", "Updated Org".getBytes());

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/TestApplication.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/TestApplication.java
@@ -1,9 +1,18 @@
 package com.swcampus.infra.postgres;
 
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
-@EnableJpaAuditing
+/**
+ * infra:db-postgres 모듈의 단위 테스트용 설정
+ * @SpringBootApplication 대신 명시적 설정을 사용하여
+ * 메인 애플리케이션 실행 시 빈 충돌 방지
+ */
+@Configuration
+@EnableAutoConfiguration
+@EntityScan(basePackages = "com.swcampus.infra.postgres")
+@EnableJpaRepositories(basePackages = "com.swcampus.infra.postgres")
 public class TestApplication {
 }

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/TestJpaConfig.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/TestJpaConfig.java
@@ -1,0 +1,9 @@
+package com.swcampus.infra.postgres;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfig {
+}

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/auth/EmailVerificationRepositoryTest.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/auth/EmailVerificationRepositoryTest.java
@@ -3,6 +3,7 @@ package com.swcampus.infra.postgres.auth;
 import com.swcampus.domain.auth.EmailVerification;
 import com.swcampus.domain.auth.EmailVerificationRepository;
 import com.swcampus.infra.postgres.TestApplication;
+import com.swcampus.infra.postgres.TestJpaConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = TestApplication.class)
-@Import(EmailVerificationEntityRepository.class)
+@Import({EmailVerificationEntityRepository.class, TestJpaConfig.class})
 @ActiveProfiles("test")
 class EmailVerificationRepositoryTest {
 

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/auth/RefreshTokenRepositoryTest.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/auth/RefreshTokenRepositoryTest.java
@@ -3,6 +3,7 @@ package com.swcampus.infra.postgres.auth;
 import com.swcampus.domain.auth.RefreshToken;
 import com.swcampus.domain.auth.RefreshTokenRepository;
 import com.swcampus.infra.postgres.TestApplication;
+import com.swcampus.infra.postgres.TestJpaConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = TestApplication.class)
-@Import(RefreshTokenEntityRepository.class)
+@Import({RefreshTokenEntityRepository.class, TestJpaConfig.class})
 @ActiveProfiles("test")
 class RefreshTokenRepositoryTest {
 

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/member/MemberRepositoryTest.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/member/MemberRepositoryTest.java
@@ -2,18 +2,24 @@ package com.swcampus.infra.postgres.member;
 
 import com.swcampus.domain.member.Member;
 import com.swcampus.domain.member.MemberRepository;
+import com.swcampus.infra.postgres.TestApplication;
+import com.swcampus.infra.postgres.TestJpaConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ContextConfiguration(classes = TestApplication.class)
+@Import(TestJpaConfig.class)
 @ActiveProfiles("test")
 @DisplayName("MemberRepository 테스트")
 class MemberRepositoryTest {

--- a/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/organization/OrganizationRepositoryTest.java
+++ b/sw-campus-infra/db-postgres/src/test/java/com/swcampus/infra/postgres/organization/OrganizationRepositoryTest.java
@@ -4,6 +4,7 @@ import com.swcampus.domain.common.ApprovalStatus;
 import com.swcampus.domain.organization.Organization;
 import com.swcampus.domain.organization.OrganizationRepository;
 import com.swcampus.infra.postgres.TestApplication;
+import com.swcampus.infra.postgres.TestJpaConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ContextConfiguration(classes = TestApplication.class)
-@Import(OrganizationEntityRepository.class)
+@Import({OrganizationEntityRepository.class, TestJpaConfig.class})
 @ActiveProfiles("test")
 class OrganizationRepositoryTest {
 


### PR DESCRIPTION
## 📋 PR 요약

비밀번호 찾기 기능 고도화 이후 깨진 테스트를 수정하고, VS Code launcher 실행 시 발생하는 빈 충돌 및 파라미터 인식 문제를 해결합니다.

## 🔗 관련 이슈

없음 (hotfix)

## 📝 변경 사항

- AuthIntegrationTest: 임시 비밀번호 요청 시 존재하지 않는 사용자 응답 변경 (200 → 400)
- MypageControllerTest: mock 메서드명 수정 (getApprovedOrganizationByUserId → getOrganizationByUserId)
- TestApplication: `@SpringBootApplication` → `@Configuration` + 명시적 설정으로 변경
  - 메인 실행 시 빈 충돌 방지 (jpaAuditingHandler, socialAccountJpaRepository)
- TestJpaConfig 생성하여 테스트에서 명시적으로 JPA Auditing 설정 import
- `@RequestParam` name 속성 추가 (OrganizationController, TeacherController, AdminBannerController)
  - VS Code launcher 실행 시 `-parameters` 플래그 관련 에러 해결

## 💬 리뷰어에게 (선택)

VS Code F5 실행 시 테스트 클래스패스가 메인과 함께 로드되어 발생하는 문제들을 해결했습니다.
TestApplication의 구조 변경은 테스트에서 필요한 설정을 명시적으로 선언하는 Spring 테스트 권장 패턴을 따릅니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)