### PR TITLE
refactor: HealthController 및 Actuator base-path 수정

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/health/HealthController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/health/HealthController.java
@@ -1,5 +1,6 @@
 package com.swcampus.api.health;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -7,8 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class HealthController {
 
     @GetMapping("/health")
-    public String health() {
-        return "ok";
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("OK");
     }
 }
 

--- a/sw-campus-api/src/main/resources/application.yml
+++ b/sw-campus-api/src/main/resources/application.yml
@@ -62,7 +62,7 @@ server:
 management:
   endpoints:
     web:
-      base-path: /
+      base-path: /actuator
       exposure:
         include: health
   endpoint:


### PR DESCRIPTION
- HealthController: ResponseEntity.ok("OK") 반환으로 변경
- application.yml: management.endpoints.web.base-path를 /actuator로 변경
- ALB는 /health, 내부 모니터링은 /actuator/health 사용

## 📋 PR 요약

<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요 -->

## 🔗 관련 이슈

closes #

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
