### PR TITLE
fix: GitHub OAuth name이 null일 때 username 사용

### DIFF
--- a/sw-campus-infra/oauth/src/main/java/com/swcampus/infra/oauth/GitHubOAuthClient.java
+++ b/sw-campus-infra/oauth/src/main/java/com/swcampus/infra/oauth/GitHubOAuthClient.java
@@ -76,7 +76,7 @@ public class GitHubOAuthClient implements OAuthClient {
             .provider(OAuthProvider.GITHUB)
             .providerId(String.valueOf(body.get("id")))
             .email(email)
-            .name(name != null ? name : login)  // name 없으면 username 사용
+            .name(name != null && !name.isBlank() ? name : login)  // name 없으면 username 사용
             .build();
     }
 


### PR DESCRIPTION
## 📋 PR 요약

GitHub OAuth 로그인 시 프로필에 이름을 설정하지 않은 사용자의 회원가입 실패 문제를 해결합니다.

## 🔗 관련 이슈

N/A (Hotfix)

## 📝 변경 사항

- GitHub API에서 `name`이 null로 반환되는 경우 `login`(username)을 대신 사용
- `members.name` NOT NULL 제약조건 위반 에러 해결

## 💬 리뷰어에게 (선택)

GitHub 프로필의 Name 필드는 선택사항이라 설정하지 않은 사용자는 null이 반환됩니다.
이 경우 항상 존재하는 username(login)을 name으로 사용합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)