### PR TITLE
fix: 워크플로우에서 application-prod.yml을 올바른 경로에 복사

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Inject config by branch
         run: |
           if [ "${{ github.ref }}" = "refs/heads/develop" ]; then
-            cp ./config/application-staging.yml ./sw-campus-api/src/main/resources/application.yml
+            cp ./config/application-staging.yml ./sw-campus-api/src/main/resources/config/application-staging.yml
           else
-            cp ./config/application-prod.yml ./sw-campus-api/src/main/resources/application.yml
+            cp ./config/application-prod.yml ./sw-campus-api/src/main/resources/config/application-prod.yml
           fi
 
       - name: Set up JDK 17


### PR DESCRIPTION
문제:
- Spring Boot는 classpath:config/application-prod.yml을 로드함
- 워크플로우가 application-prod.yml을 application.yml로 복사함
- 결과적으로 application-prod.yml이 로드되지 않음
- Spring Batch 자동 실행 비활성화 설정이 적용되지 않음

해결:
- config 서브모듈 디렉토리에 application-prod.yml을 복사
- develop 브랜치는 application-staging.yml을 config/application-staging.yml로 복사
- main 브랜치는 application-prod.yml을 config/application-prod.yml로 복사

변경 파일:
- .github/workflows/build.yml: config 서브모듈 경로에 파일 복사

## 📋 PR 요약

<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요 -->

## 🔗 관련 이슈

closes #

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
