### PR TITLE
refactor: Actuator 별도 포트 분리로 인한 Security 설정 주석 처리

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/config/SecurityConfig.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/config/SecurityConfig.java
@@ -65,16 +65,14 @@ public class SecurityConfig {
                 })
             )
             .authorizeHttpRequests(auth -> auth
-                // ✅ ALB / Kubernetes Health Check (무조건 허용 - 제일 먼저 체크)
-                // - /actuator/health/readiness: Kubernetes readiness probe용
-                // - /actuator/health/liveness: Kubernetes liveness probe용
-                // - /actuator/health: 기본 health check
-                // ⚠️ 인증 없이 접근 가능해야 ALB/Kubernetes probe가 정상 작동
-                // ⚠️ permitAll()만으로는 부족 - JwtAuthenticationFilter에서도 shouldNotFilter로 제외해야 함
-                .requestMatchers(
-                    "/actuator/health",
-                    "/actuator/health/**"
-                ).permitAll()
+                // ❌ Actuator는 별도 포트(9090)로 분리되어 더 이상 필요 없음
+                // - 메인 API 포트(8080)와 헬스체크 포트(9090) 물리적 분리
+                // - JWT / Security / Filter 전부 무시됨 (포트 자체가 다르므로 인증 개입 불가)
+                // - 아래 설정은 유지해도 무방하지만 실제로는 사용되지 않음
+                // .requestMatchers(
+                //     "/actuator/health",
+                //     "/actuator/health/**"
+                // ).permitAll()
 
                 // Auth
                 .requestMatchers("/api/v1/auth/**").permitAll()

--- a/sw-campus-api/src/main/java/com/swcampus/api/security/JwtAuthenticationFilter.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/security/JwtAuthenticationFilter.java
@@ -22,13 +22,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
 
-    // ✅ 헬스체크 / actuator 는 JWT 필터 자체를 타지 않음
-    // ⚠️ SecurityConfig의 permitAll()과 반드시 동일한 범위여야 함
-    // ⚠️ 이거 없으면 permitAll 해도 필터가 먼저 실행돼서 막힘
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getRequestURI().startsWith("/actuator/health");
-    }
+    // ❌ Actuator는 별도 포트(9090)로 분리되어 더 이상 필요 없음
+    // - 메인 API 포트(8080)와 헬스체크 포트(9090) 물리적 분리
+    // - JWT / Security / Filter 전부 무시됨 (포트 자체가 다르므로 인증 개입 불가)
+    // - 아래 설정은 유지해도 무방하지만 실제로는 사용되지 않음
+    // @Override
+    // protected boolean shouldNotFilter(HttpServletRequest request) {
+    //     return request.getRequestURI().startsWith("/actuator/health");
+    // }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,


### PR DESCRIPTION
Actuator가 별도 포트(9090)로 분리되어:
- 메인 API 포트(8080)와 헬스체크 포트(9090) 물리적 분리
- JWT / Security / Filter 전부 무시됨 (포트 자체가 다르므로 인증 개입 불가)
- SecurityConfig의 actuator permitAll 설정 불필요
- JwtAuthenticationFilter의 shouldNotFilter 설정 불필요

변경 사항:
- SecurityConfig: actuator permitAll 설정 주석 처리
- JwtAuthenticationFilter: shouldNotFilter 설정 주석 처리

변경 파일:
- SecurityConfig.java: actuator permitAll 주석 처리
- JwtAuthenticationFilter.java: shouldNotFilter 주석 처리

## 📋 PR 요약

<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요 -->

## 🔗 관련 이슈

closes #

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
