### PR TITLE
fix(docker): Dockerfile에 누락된 모듈 build.gradle 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,13 @@ COPY gradle ./gradle
 COPY sw-campus-api/build.gradle ./sw-campus-api/
 COPY sw-campus-domain/build.gradle ./sw-campus-domain/
 COPY sw-campus-shared/logging/build.gradle ./sw-campus-shared/logging/
+COPY sw-campus-shared/error/build.gradle ./sw-campus-shared/error/
 COPY sw-campus-infra/db-postgres/build.gradle ./sw-campus-infra/db-postgres/
+COPY sw-campus-infra/db-redis/build.gradle ./sw-campus-infra/db-redis/
 COPY sw-campus-infra/oauth/build.gradle ./sw-campus-infra/oauth/
+COPY sw-campus-infra/ocr/build.gradle ./sw-campus-infra/ocr/
 COPY sw-campus-infra/s3/build.gradle ./sw-campus-infra/s3/
+COPY sw-campus-infra/analytics/build.gradle ./sw-campus-infra/analytics/
 
 # 캐시(의존성)만 먼저 당겨놓기
 RUN gradle :sw-campus-api:dependencies --no-daemon || true


### PR DESCRIPTION
## 📋 PR 요약

Docker 빌드 시 의존성 캐싱 레이어에서 누락된 모듈들의 build.gradle 파일을 추가합니다.

## 🔗 관련 이슈

N/A

## 📝 변경 사항

- `sw-campus-shared/error/build.gradle` 추가
- `sw-campus-infra/db-redis/build.gradle` 추가
- `sw-campus-infra/ocr/build.gradle` 추가
- `sw-campus-infra/analytics/build.gradle` 추가

## 💬 리뷰어에게 (선택)

누락된 모듈들이 의존성 캐싱 단계에 포함되지 않아 Docker 빌드 캐싱이 비효율적으로 동작할 수 있었습니다. 이번 수정으로 모든 모듈의 build.gradle이 포함되어 의존성 캐싱이 정상 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)