### PR TITLE
docs(swagger): 에러 응답에 content + examples 추가

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminBannerController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminBannerController.java
@@ -8,8 +8,12 @@ import com.swcampus.domain.lecture.AdminBannerService;
 import com.swcampus.domain.lecture.BannerPeriodStatus;
 import com.swcampus.domain.lecture.BannerType;
 import com.swcampus.domain.lecture.dto.BannerDetailsDto;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -70,8 +74,16 @@ public class AdminBannerController {
         @Operation(summary = "배너 상태별 통계 조회", description = "전체/활성/비활성/예정/진행중/종료 배너 수를 조회합니다.")
         @ApiResponses({
                         @ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @ApiResponse(responseCode = "401", description = "인증 필요"),
-                        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+                        @ApiResponse(responseCode = "401", description = "인증 필요",
+                                content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                        examples = @ExampleObject(value = """
+                                                {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                                """))),
+                        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                                content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                        examples = @ExampleObject(value = """
+                                                {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                                """)))
         })
         @GetMapping("/stats")
         public ResponseEntity<BannerStatsResponse> getStats() {
@@ -84,8 +96,16 @@ public class AdminBannerController {
         @Operation(summary = "배너 목록 조회", description = "배너를 검색합니다. 키워드, 기간 상태, 배너 타입으로 필터링하고 페이징 처리됩니다.")
         @ApiResponses({
                         @ApiResponse(responseCode = "200", description = "조회 성공"),
-                        @ApiResponse(responseCode = "401", description = "인증 필요"),
-                        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+                        @ApiResponse(responseCode = "401", description = "인증 필요",
+                                content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                        examples = @ExampleObject(value = """
+                                                {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                                """))),
+                        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                                content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                                        examples = @ExampleObject(value = """
+                                                {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                                """)))
         })
         @GetMapping
         public ResponseEntity<Page<AdminBannerResponse>> getBanners(

--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminMemberController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminMemberController.java
@@ -21,6 +21,7 @@ import com.swcampus.domain.member.Role;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -41,8 +42,16 @@ public class AdminMemberController {
     @Operation(summary = "회원 역할별 통계 조회", description = "전체/일반/기관/관리자 회원 수를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/stats")
     public ResponseEntity<MemberRoleStatsResponse> getStats() {
@@ -53,8 +62,16 @@ public class AdminMemberController {
     @Operation(summary = "회원 목록 조회/검색", description = "회원 목록을 조회하고 검색합니다. 역할과 이름, 닉네임, 이메일로 필터링할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping
     public ResponseEntity<Page<AdminMemberResponse>> getMembers(

--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminReviewController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminReviewController.java
@@ -9,8 +9,12 @@ import com.swcampus.domain.storage.PresignedUrlService;
 import com.swcampus.domain.common.ApprovalStatus;
 import com.swcampus.domain.review.Review;
 import com.swcampus.domain.review.dto.PendingReviewInfo;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -45,8 +49,16 @@ public class AdminReviewController {
     @Operation(summary = "수료증 상태별 통계 조회", description = "전체/대기/승인/반려 수료증 수를 조회합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/certificates/stats")
     public ResponseEntity<ApprovalStatsResponse> getCertificateStats() {
@@ -57,8 +69,16 @@ public class AdminReviewController {
     @Operation(summary = "리뷰 상태별 통계 조회", description = "전체/대기/승인/반려 리뷰 수를 조회합니다. (수료증 승인된 리뷰만 카운트)")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/reviews/stats")
     public ResponseEntity<ApprovalStatsResponse> getReviewStats() {
@@ -69,8 +89,16 @@ public class AdminReviewController {
     @Operation(summary = "대기 중인 후기 목록 조회", description = "수료증 또는 후기가 PENDING 상태인 목록을 조회합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/reviews")
     public ResponseEntity<AdminReviewListResponse> getPendingReviews() {
@@ -86,8 +114,16 @@ public class AdminReviewController {
     @Operation(summary = "전체 후기 목록 조회", description = "모든 후기를 조회합니다. 승인 상태 필터링, 강의명 검색, 페이지네이션을 지원합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/reviews/all")
     public ResponseEntity<Page<AdminReviewListResponse.AdminReviewSummary>> getAllReviews(

--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminSurveyController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminSurveyController.java
@@ -3,8 +3,12 @@ package com.swcampus.api.admin;
 import com.swcampus.api.survey.response.SurveyResponse;
 import com.swcampus.domain.survey.MemberSurvey;
 import com.swcampus.domain.survey.MemberSurveyService;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -33,8 +37,16 @@ public class AdminSurveyController {
     @Operation(summary = "전체 설문조사 목록 조회", description = "모든 회원의 설문조사를 페이징 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping
     public ResponseEntity<Page<SurveyResponse>> getSurveys(
@@ -48,9 +60,21 @@ public class AdminSurveyController {
     @Operation(summary = "특정 회원 설문조사 조회", description = "특정 회원의 설문조사를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요"),
-            @ApiResponse(responseCode = "404", description = "설문조사 없음")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "설문조사 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 404, "message": "설문조사를 찾을 수 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/members/{memberId}")
     public ResponseEntity<SurveyResponse> getSurvey(

--- a/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminTestDataController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/admin/AdminTestDataController.java
@@ -5,7 +5,11 @@ import com.swcampus.api.admin.response.TestDataSummaryResponse;
 import com.swcampus.domain.testdata.TestDataCreateResult;
 import com.swcampus.domain.testdata.TestDataService;
 import com.swcampus.domain.testdata.TestDataSummary;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -28,9 +32,21 @@ public class AdminTestDataController {
                     "이미 테스트 데이터가 존재하면 먼저 삭제해야 합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "이미 테스트 데이터가 존재함"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+            @ApiResponse(responseCode = "400", description = "이미 테스트 데이터가 존재함",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 400, "message": "이미 테스트 데이터가 존재합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @PostMapping
     public ResponseEntity<TestDataCreateResponse> createTestData() {
@@ -43,9 +59,21 @@ public class AdminTestDataController {
                     "실제 사용자 데이터는 삭제되지 않습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "삭제할 테스트 데이터가 없음"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+            @ApiResponse(responseCode = "400", description = "삭제할 테스트 데이터가 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 400, "message": "삭제할 테스트 데이터가 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @DeleteMapping
     public ResponseEntity<Void> deleteTestData() {
@@ -57,8 +85,16 @@ public class AdminTestDataController {
             description = "현재 생성된 테스트 데이터의 현황을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/summary")
     public ResponseEntity<TestDataSummaryResponse> getSummary() {

--- a/sw-campus-api/src/main/java/com/swcampus/api/auth/PasswordController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/auth/PasswordController.java
@@ -15,7 +15,11 @@ import com.swcampus.api.auth.request.TemporaryPasswordRequest;
 import com.swcampus.domain.auth.PasswordService;
 import com.swcampus.domain.auth.TokenProvider;
 
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -37,8 +41,16 @@ public class PasswordController {
     @SecurityRequirement(name = "cookieAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "변경 성공"),
-        @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "400", description = "현재 비밀번호 불일치",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "현재 비밀번호가 일치하지 않습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     public ResponseEntity<Void> changePassword(
             @CookieValue(name = "accessToken") String accessToken,

--- a/sw-campus-api/src/main/java/com/swcampus/api/cart/CartController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/cart/CartController.java
@@ -16,8 +16,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -36,9 +40,21 @@ public class CartController {
     @Operation(summary = "장바구니 추가", description = "강의를 장바구니에 추가합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "추가 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 장바구니에 존재")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 404, "message": "강의를 찾을 수 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "409", description = "이미 장바구니에 존재",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 409, "message": "이미 장바구니에 존재합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     public ResponseEntity<Void> addCart(
             @CurrentMember MemberPrincipal member,
@@ -53,8 +69,16 @@ public class CartController {
     @Operation(summary = "장바구니 삭제", description = "장바구니에서 강의를 제거합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "404", description = "장바구니에 해당 강의 없음")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "404", description = "장바구니에 해당 강의 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 404, "message": "장바구니에 해당 강의가 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     public ResponseEntity<Void> removeCart(
             @CurrentMember MemberPrincipal member,
@@ -69,7 +93,11 @@ public class CartController {
     @Operation(summary = "장바구니 목록 조회", description = "장바구니에 담긴 강의 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요")
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     public ResponseEntity<List<CartLectureResponse>> getCart(
             @CurrentMember MemberPrincipal member) {

--- a/sw-campus-api/src/main/java/com/swcampus/api/certificate/CertificateController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/certificate/CertificateController.java
@@ -6,8 +6,12 @@ import com.swcampus.api.security.CurrentMember;
 import com.swcampus.domain.auth.MemberPrincipal;
 import com.swcampus.domain.certificate.Certificate;
 import com.swcampus.domain.certificate.CertificateService;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -32,7 +36,11 @@ public class CertificateController {
     @SecurityRequirement(name = "cookieAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/check")
     public ResponseEntity<CertificateCheckResponse> checkCertificate(
@@ -56,9 +64,21 @@ public class CertificateController {
     @SecurityRequirement(name = "cookieAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "인증 성공"),
-        @ApiResponse(responseCode = "400", description = "강의명 불일치"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "409", description = "이미 인증된 수료증")
+        @ApiResponse(responseCode = "400", description = "강의명 불일치",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "강의명이 일치하지 않습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "409", description = "이미 인증된 수료증",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 409, "message": "이미 인증된 수료증입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PostMapping(value = "/verify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CertificateVerifyResponse> verifyCertificate(

--- a/sw-campus-api/src/main/java/com/swcampus/api/lecture/AdminLectureController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/lecture/AdminLectureController.java
@@ -47,8 +47,16 @@ public class AdminLectureController {
     @Operation(summary = "강의 상태별 통계 조회", description = "전체/대기/승인/반려 강의 수를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/stats")
     public ResponseEntity<ApprovalStatsResponse> getStats() {
@@ -59,8 +67,16 @@ public class AdminLectureController {
     @Operation(summary = "강의 목록 조회/검색", description = "강의 목록을 조회하고 검색합니다. 승인 상태와 강의명으로 필터링할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping
     public ResponseEntity<Page<AdminLectureSummaryResponse>> getLectures(

--- a/sw-campus-api/src/main/java/com/swcampus/api/lecture/LectureController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/lecture/LectureController.java
@@ -36,8 +36,12 @@ import com.swcampus.domain.organization.OrganizationService;
 import com.swcampus.domain.review.ReviewService;
 import com.swcampus.domain.review.ReviewWithNickname;
 
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -68,8 +72,16 @@ public class LectureController {
 	@SecurityRequirement(name = "cookieAuth")
 	@ApiResponses({
 			@ApiResponse(responseCode = "201", description = "등록 성공 (승인 대기)"),
-			@ApiResponse(responseCode = "401", description = "인증 필요"),
-			@ApiResponse(responseCode = "403", description = "권한 없음")
+			@ApiResponse(responseCode = "401", description = "인증 필요",
+					content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(value = """
+									{"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+									"""))),
+			@ApiResponse(responseCode = "403", description = "권한 없음",
+					content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(value = """
+									{"status": 403, "message": "접근 권한이 없습니다", "timestamp": "2025-12-09T12:00:00"}
+									""")))
 	})
 	public ResponseEntity<LectureResponse> createLecture(
 			@CurrentMember MemberPrincipal member,
@@ -110,9 +122,21 @@ public class LectureController {
 	@SecurityRequirement(name = "cookieAuth")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "수정 성공"),
-			@ApiResponse(responseCode = "401", description = "인증 필요"),
-			@ApiResponse(responseCode = "403", description = "권한 없음"),
-			@ApiResponse(responseCode = "404", description = "강의 없음")
+			@ApiResponse(responseCode = "401", description = "인증 필요",
+					content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(value = """
+									{"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+									"""))),
+			@ApiResponse(responseCode = "403", description = "권한 없음",
+					content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(value = """
+									{"status": 403, "message": "접근 권한이 없습니다", "timestamp": "2025-12-09T12:00:00"}
+									"""))),
+			@ApiResponse(responseCode = "404", description = "강의 없음",
+					content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+							examples = @ExampleObject(value = """
+									{"status": 404, "message": "강의를 찾을 수 없습니다", "timestamp": "2025-12-09T12:00:00"}
+									""")))
 	})
 	public ResponseEntity<LectureResponse> updateLecture(
 			@CurrentMember MemberPrincipal member,

--- a/sw-campus-api/src/main/java/com/swcampus/api/mypage/MypageController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/mypage/MypageController.java
@@ -25,7 +25,11 @@ import com.swcampus.domain.organization.OrganizationService;
 import com.swcampus.domain.review.ReviewService;
 import com.swcampus.domain.review.ReviewWithNickname;
 import com.swcampus.domain.survey.MemberSurveyService;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -65,7 +69,11 @@ public class MypageController {
     @Operation(summary = "[공통] 비밀번호 확인", description = "[공통] 회원정보 수정 화면 진입 전 비밀번호를 확인합니다. 소셜 로그인 사용자는 비밀번호 검증 없이 항상 true를 반환합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "확인 완료"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PostMapping("/verify-password")
     @PreAuthorize("isAuthenticated()")
@@ -80,7 +88,11 @@ public class MypageController {
     @Operation(summary = "[공통] 내 정보 조회", description = "[공통] 로그인한 사용자의 프로필 정보를 조회합니다. 일반 사용자와 기관 모두 사용 가능합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/profile")
     @PreAuthorize("isAuthenticated()")
@@ -96,8 +108,16 @@ public class MypageController {
     @Operation(summary = "[공통] 내 정보 수정", description = "[공통] 로그인한 사용자의 프로필 정보(닉네임, 연락처, 주소)를 수정합니다. 일반 사용자와 기관 모두 사용 가능합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "수정 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PatchMapping("/profile")
     @PreAuthorize("isAuthenticated()")
@@ -112,8 +132,16 @@ public class MypageController {
     @Operation(summary = "[일반 사용자 전용] 내 수강 완료 강의 조회", description = "[일반 사용자 전용] 수료증 인증이 승인된 강의 목록을 조회합니다. 각 강의에 대해 후기 작성 가능 여부(canWriteReview)를 함께 반환합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공 (없을 경우 빈 배열)"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "일반 사용자만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/completed-lectures")
     @PreAuthorize("hasRole('USER')")
@@ -128,9 +156,21 @@ public class MypageController {
     @Operation(summary = "[일반 사용자 전용] 수강 완료 강의 후기 상세 조회", description = "[일반 사용자 전용] 수강 완료한 강의에 대해 본인이 작성한 후기 상세 정보를 조회합니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님"),
-        @ApiResponse(responseCode = "404", description = "해당 강의에 대한 후기가 없음")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "일반 사용자만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "404", description = "해당 강의에 대한 후기가 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 404, "message": "해당 강의에 대한 후기가 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/completed-lectures/{lectureId}/review")
     @PreAuthorize("hasRole('USER')")
@@ -148,8 +188,16 @@ public class MypageController {
     @Operation(summary = "[일반 사용자 전용] 설문조사 조회", description = "[일반 사용자 전용] 강의 추천을 위한 나의 설문조사 정보를 조회합니다. 전공, 부트캠프 수료 여부, 희망 직무 등의 정보를 확인할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "일반 사용자만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/survey")
     @PreAuthorize("hasRole('USER')")
@@ -163,9 +211,21 @@ public class MypageController {
     @Operation(summary = "[일반 사용자 전용] 설문조사 등록/수정", description = "[일반 사용자 전용] 강의 추천을 위한 설문조사 정보를 등록하거나 수정합니다. 이미 등록된 경우 덮어씁니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "저장 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님")
+        @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "일반 사용자가 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "일반 사용자만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PutMapping("/survey")
     @PreAuthorize("hasRole('USER')")
@@ -188,8 +248,16 @@ public class MypageController {
     @Operation(summary = "[기관 전용] 등록 강의 목록 조회", description = "[기관 전용] 우리 기관에서 등록한 강의 목록을 조회합니다. 강의 상태, 수강생 수 등을 확인할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "기관 회원이 아님")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "기관 회원이 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "기관 회원만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/lectures")
     @PreAuthorize("hasRole('ORGANIZATION')")
@@ -207,9 +275,21 @@ public class MypageController {
     @Operation(summary = "[기관 전용] 등록 강의 상세 조회", description = "[기관 전용] 우리 기관에서 등록한 강의의 상세 정보를 조회합니다. 승인 상태와 관계없이 조회할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "기관 회원이 아니거나 본인 강의가 아님"),
-        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "기관 회원이 아니거나 본인 강의가 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "본인 기관의 강의만 조회할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "404", description = "강의를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 404, "message": "강의를 찾을 수 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/lectures/{lectureId}")
     @PreAuthorize("hasRole('ORGANIZATION')")
@@ -232,8 +312,16 @@ public class MypageController {
     @Operation(summary = "[기관 전용] 기관 정보 조회", description = "[기관 전용] 우리 기관의 상세 정보를 조회합니다. 기관명, 설명, 로고, 시설 이미지, 정부 인증 정보 등을 확인할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "기관 회원이 아님")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "기관 회원이 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "기관 회원만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/organization")
     @PreAuthorize("hasRole('ORGANIZATION')")
@@ -246,9 +334,21 @@ public class MypageController {
     @Operation(summary = "[기관 전용] 기관 정보 수정", description = "[기관 전용] 우리 기관의 정보를 수정합니다. 기관명, 설명, 로고, 시설 이미지, 사업자등록증 등을 업로드할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "수정 성공"),
-        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "기관 회원이 아님")
+        @ApiResponse(responseCode = "400", description = "잘못된 요청",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "기관 회원이 아님",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "기관 회원만 접근할 수 있습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PatchMapping(value = "/organization", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('ORGANIZATION')")

--- a/sw-campus-api/src/main/java/com/swcampus/api/organization/AdminOrganizationController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/organization/AdminOrganizationController.java
@@ -51,8 +51,16 @@ public class AdminOrganizationController {
     @Operation(summary = "기관 상태별 통계 조회", description = "전체/대기/승인/반려 기관 수를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/stats")
     public ResponseEntity<ApprovalStatsResponse> getStats() {
@@ -63,8 +71,16 @@ public class AdminOrganizationController {
     @Operation(summary = "기관 목록 조회/검색", description = "기관 목록을 조회하고 검색합니다. 상태와 기관명으로 필터링할 수 있습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "관리자 권한 필요", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "관리자 권한 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @io.swagger.v3.oas.annotations.media.ExampleObject(value = """
+                                    {"status": 403, "message": "관리자 권한이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping
     public ResponseEntity<Page<AdminOrganizationSummaryResponse>> getOrganizations(

--- a/sw-campus-api/src/main/java/com/swcampus/api/review/ReviewController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/review/ReviewController.java
@@ -43,7 +43,11 @@ public class ReviewController {
     @SecurityRequirement(name = "cookieAuth")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
-        @ApiResponse(responseCode = "401", description = "인증 필요")
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @GetMapping("/eligibility")
     public ResponseEntity<ReviewEligibilityResponse> checkEligibility(
@@ -83,10 +87,26 @@ public class ReviewController {
                       "updatedAt": "2025-12-10T10:30:00"
                     }
                     """))),
-        @ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "수료증 인증 필요"),
-        @ApiResponse(responseCode = "409", description = "이미 작성한 후기 존재")
+        @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "수료증 인증 필요",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "수료증 인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "409", description = "이미 작성한 후기 존재",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 409, "message": "이미 작성한 후기가 존재합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PostMapping
     public ResponseEntity<ReviewResponse> createReview(
@@ -158,10 +178,26 @@ public class ReviewController {
                       "updatedAt": "2025-12-15T14:20:00"
                     }
                     """))),
-        @ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
-        @ApiResponse(responseCode = "401", description = "인증 필요"),
-        @ApiResponse(responseCode = "403", description = "본인 후기만 수정 가능 / 승인된 후기 수정 불가"),
-        @ApiResponse(responseCode = "404", description = "후기를 찾을 수 없음")
+        @ApiResponse(responseCode = "400", description = "유효성 검증 실패",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "401", description = "인증 필요",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "403", description = "본인 후기만 수정 가능 / 승인된 후기 수정 불가",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 403, "message": "접근 권한이 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """))),
+        @ApiResponse(responseCode = "404", description = "후기를 찾을 수 없음",
+            content = @Content(schema = @Schema(implementation = com.swcampus.api.exception.ErrorResponse.class),
+                examples = @ExampleObject(value = """
+                    {"status": 404, "message": "후기를 찾을 수 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                    """)))
     })
     @PutMapping("/{reviewId}")
     public ResponseEntity<ReviewResponse> updateReview(

--- a/sw-campus-api/src/main/java/com/swcampus/api/storage/StorageController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/storage/StorageController.java
@@ -8,8 +8,12 @@ import com.swcampus.api.storage.response.PresignedUrlResponse;
 import com.swcampus.domain.auth.MemberPrincipal;
 import com.swcampus.domain.member.Role;
 import com.swcampus.domain.storage.PresignedUrlService;
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -33,7 +37,11 @@ public class StorageController {
     @Operation(summary = "Presigned GET URL 발급", description = "S3 객체에 접근하기 위한 Presigned GET URL을 발급합니다. Public 파일은 인증 없이, Private 파일은 관리자만 접근 가능합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "발급 성공"),
-            @ApiResponse(responseCode = "403", description = "Private 파일에 대한 접근 권한 없음")
+            @ApiResponse(responseCode = "403", description = "Private 파일에 대한 접근 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "접근 권한이 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @GetMapping("/presigned-urls")
     public ResponseEntity<PresignedUrlResponse> getPresignedUrl(
@@ -51,7 +59,11 @@ public class StorageController {
     @Operation(summary = "배치 Presigned GET URL 발급", description = "여러 S3 객체에 대한 Presigned GET URL을 일괄 발급합니다. Private 파일에 대해 권한이 없으면 해당 key의 값은 null로 반환됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "발급 성공"),
-            @ApiResponse(responseCode = "400", description = "요청 개수가 50개 초과")
+            @ApiResponse(responseCode = "400", description = "요청 개수가 50개 초과",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 400, "message": "요청 개수가 50개를 초과했습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @PostMapping("/presigned-urls/batch")
     public ResponseEntity<Map<String, String>> getPresignedUrlBatch(
@@ -69,9 +81,21 @@ public class StorageController {
     @SecurityRequirement(name = "cookieAuth")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "발급 성공"),
-            @ApiResponse(responseCode = "400", description = "지원하지 않는 카테고리"),
-            @ApiResponse(responseCode = "401", description = "인증 필요"),
-            @ApiResponse(responseCode = "403", description = "해당 카테고리에 대한 업로드 권한 없음")
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 카테고리",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 400, "message": "지원하지 않는 카테고리입니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 401, "message": "인증이 필요합니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """))),
+            @ApiResponse(responseCode = "403", description = "해당 카테고리에 대한 업로드 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 403, "message": "접근 권한이 없습니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @PostMapping("/presigned-urls/upload")
     public ResponseEntity<PresignedUploadResponse> getPresignedUploadUrl(

--- a/sw-campus-api/src/main/java/com/swcampus/api/teacher/TeacherController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/teacher/TeacherController.java
@@ -18,8 +18,12 @@ import com.swcampus.api.teacher.response.TeacherResponse;
 import com.swcampus.domain.teacher.Teacher;
 import com.swcampus.domain.teacher.TeacherService;
 
+import com.swcampus.api.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -51,7 +55,11 @@ public class TeacherController {
     @Operation(summary = "강사 등록", description = "새로운 강사를 등록합니다. (이미지 포함)")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {"status": 400, "message": "잘못된 요청입니다", "timestamp": "2025-12-09T12:00:00"}
+                                    """)))
     })
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<TeacherResponse> createTeacher(


### PR DESCRIPTION
## 📋 PR 요약

모든 API 에러 응답(400, 401, 403, 404, 409)에 `content`와 `examples`를 추가하여 Swagger UI에서 실제 에러 형태와 예시 메시지를 확인할 수 있도록 개선했습니다.

## 🔗 관련 이슈

closes #317

## 📝 변경 사항

- 15개 Controller의 `@ApiResponse` 에러 응답에 `content` + `examples` 추가
  - AdminBannerController, AdminMemberController, AdminReviewController
  - AdminSurveyController, AdminTestDataController, PasswordController
  - CartController, CertificateController, AdminLectureController
  - LectureController, MypageController, AdminOrganizationController
  - ReviewController, StorageController, TeacherController
- 에러 응답 예시에 올바른 status 코드와 메시지 포함
  - 401: `{"status": 401, "message": "인증이 필요합니다", ...}`
  - 403: `{"status": 403, "message": "접근 권한이 없습니다", ...}`
  - 등

## 💬 리뷰어에게 (선택)

기존에 `@ApiResponse`에 `content` 속성 없이 에러 응답을 정의하면 Swagger에서 기본 ErrorResponse 예시(status: 400)가 표시되어 실제 에러 상태와 불일치하는 문제가 있었습니다.

이 패턴은 `sw-campus-docs/code-rules/server/07-swagger-documentation.md`에도 문서화했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)