### PR TITLE
fix(cache): Redis 캐시 역직렬화 에러 수정

### DIFF
--- a/sw-campus-domain/src/main/java/com/swcampus/domain/category/Category.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/category/Category.java
@@ -3,11 +3,16 @@ package com.swcampus.domain.category;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class Category {
 	private Long categoryId;
 	private Long pid;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/category/Curriculum.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/category/Curriculum.java
@@ -1,10 +1,15 @@
 package com.swcampus.domain.category;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class Curriculum {
 	private Long curriculumId;
 	private Long categoryId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/Lecture.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/Lecture.java
@@ -5,11 +5,16 @@ import java.time.LocalTime;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class Lecture {
 	private Long lectureId;
 	private Long orgId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureAdd.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureAdd.java
@@ -1,10 +1,15 @@
 package com.swcampus.domain.lecture;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class LectureAdd {
 	private Long addId;
 	private Long lectureId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureCurriculum.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureCurriculum.java
@@ -2,11 +2,16 @@ package com.swcampus.domain.lecture;
 
 import com.swcampus.domain.category.Curriculum;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class LectureCurriculum {
 	private Long lectureId;
 	private Long curriculumId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureQual.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureQual.java
@@ -1,10 +1,15 @@
 package com.swcampus.domain.lecture;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class LectureQual {
 	private Long qualId;
 	private Long lectureId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureStep.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureStep.java
@@ -1,11 +1,16 @@
 package com.swcampus.domain.lecture;
 
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class LectureStep {
 	private Long stepId;
 	private Long lectureId;

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/teacher/Teacher.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/teacher/Teacher.java
@@ -1,10 +1,15 @@
 package com.swcampus.domain.teacher;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder(toBuilder = true)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class Teacher {
 	private Long teacherId;
 	private String teacherName;

--- a/sw-campus-infra/db-redis/src/test/java/com/swcampus/infra/redis/lecture/LectureCacheSerializationTest.java
+++ b/sw-campus-infra/db-redis/src/test/java/com/swcampus/infra/redis/lecture/LectureCacheSerializationTest.java
@@ -1,0 +1,196 @@
+package com.swcampus.infra.redis.lecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.swcampus.domain.category.Category;
+import com.swcampus.domain.category.Curriculum;
+import com.swcampus.domain.lecture.CurriculumLevel;
+import com.swcampus.domain.lecture.Lecture;
+import com.swcampus.domain.lecture.LectureAdd;
+import com.swcampus.domain.lecture.LectureAuthStatus;
+import com.swcampus.domain.lecture.LectureCurriculum;
+import com.swcampus.domain.lecture.LectureDay;
+import com.swcampus.domain.lecture.LectureLocation;
+import com.swcampus.domain.lecture.LectureQual;
+import com.swcampus.domain.lecture.LectureQualType;
+import com.swcampus.domain.lecture.LectureStatus;
+import com.swcampus.domain.lecture.LectureStep;
+import com.swcampus.domain.lecture.RecruitType;
+import com.swcampus.domain.lecture.SelectionStepType;
+import com.swcampus.domain.teacher.Teacher;
+
+/**
+ * Redis 캐시에서 사용하는 Jackson 직렬화/역직렬화 테스트
+ * RedisConfig와 동일한 ObjectMapper 설정 사용
+ */
+class LectureCacheSerializationTest {
+
+	private ObjectMapper objectMapper;
+
+	@BeforeEach
+	void setUp() {
+		// RedisConfig와 동일한 설정
+		objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		objectMapper.activateDefaultTyping(
+				BasicPolymorphicTypeValidator.builder()
+						.allowIfBaseType(Object.class)
+						.build(),
+				ObjectMapper.DefaultTyping.NON_FINAL);
+	}
+
+	@Test
+	@DisplayName("Lecture 객체 직렬화/역직렬화 성공")
+	void serializeAndDeserializeLecture() throws Exception {
+		// given
+		Lecture lecture = createFullLecture();
+
+		// when
+		String json = objectMapper.writeValueAsString(lecture);
+		Lecture deserialized = objectMapper.readValue(json, Lecture.class);
+
+		// then
+		assertThat(deserialized).isNotNull();
+		assertThat(deserialized.getLectureId()).isEqualTo(lecture.getLectureId());
+		assertThat(deserialized.getLectureName()).isEqualTo(lecture.getLectureName());
+		assertThat(deserialized.getDays()).containsExactlyInAnyOrderElementsOf(lecture.getDays());
+		assertThat(deserialized.getStartTime()).isEqualTo(lecture.getStartTime());
+		assertThat(deserialized.getStatus()).isEqualTo(lecture.getStatus());
+	}
+
+	@Test
+	@DisplayName("Lecture의 중첩 객체(LectureStep) 역직렬화 성공")
+	void deserializeLectureWithSteps() throws Exception {
+		// given
+		Lecture lecture = createFullLecture();
+
+		// when
+		String json = objectMapper.writeValueAsString(lecture);
+		Lecture deserialized = objectMapper.readValue(json, Lecture.class);
+
+		// then
+		assertThat(deserialized.getSteps()).hasSize(1);
+		assertThat(deserialized.getSteps().get(0).getStepType()).isEqualTo(SelectionStepType.DOCUMENT);
+	}
+
+	@Test
+	@DisplayName("Lecture의 중첩 객체(Teacher) 역직렬화 성공")
+	void deserializeLectureWithTeachers() throws Exception {
+		// given
+		Lecture lecture = createFullLecture();
+
+		// when
+		String json = objectMapper.writeValueAsString(lecture);
+		Lecture deserialized = objectMapper.readValue(json, Lecture.class);
+
+		// then
+		assertThat(deserialized.getTeachers()).hasSize(1);
+		assertThat(deserialized.getTeachers().get(0).getTeacherName()).isEqualTo("홍길동");
+	}
+
+	@Test
+	@DisplayName("Lecture의 중첩 객체(LectureCurriculum -> Curriculum -> Category) 역직렬화 성공")
+	void deserializeLectureWithCurriculum() throws Exception {
+		// given
+		Lecture lecture = createFullLecture();
+
+		// when
+		String json = objectMapper.writeValueAsString(lecture);
+		Lecture deserialized = objectMapper.readValue(json, Lecture.class);
+
+		// then
+		assertThat(deserialized.getLectureCurriculums()).hasSize(1);
+		LectureCurriculum lc = deserialized.getLectureCurriculums().get(0);
+		assertThat(lc.getCurriculum()).isNotNull();
+		assertThat(lc.getCurriculum().getCurriculumName()).isEqualTo("Spring Boot");
+		assertThat(lc.getCurriculum().getCategory()).isNotNull();
+		assertThat(lc.getCurriculum().getCategory().getCategoryName()).isEqualTo("백엔드");
+	}
+
+	private Lecture createFullLecture() {
+		Category category = Category.builder()
+				.categoryId(1L)
+				.categoryName("백엔드")
+				.build();
+
+		Curriculum curriculum = Curriculum.builder()
+				.curriculumId(1L)
+				.categoryId(1L)
+				.curriculumName("Spring Boot")
+				.category(category)
+				.build();
+
+		LectureCurriculum lectureCurriculum = LectureCurriculum.builder()
+				.lectureId(19L)
+				.curriculumId(1L)
+				.level(CurriculumLevel.BASIC)
+				.curriculum(curriculum)
+				.build();
+
+		Teacher teacher = Teacher.builder()
+				.teacherId(1L)
+				.teacherName("홍길동")
+				.teacherDescription("10년차 개발자")
+				.build();
+
+		LectureStep step = LectureStep.builder()
+				.stepId(1L)
+				.lectureId(19L)
+				.stepType(SelectionStepType.DOCUMENT)
+				.stepOrder(1)
+				.build();
+
+		LectureAdd add = LectureAdd.builder()
+				.addId(1L)
+				.lectureId(19L)
+				.addName("노트북 지원")
+				.build();
+
+		LectureQual qual = LectureQual.builder()
+				.qualId(1L)
+				.lectureId(19L)
+				.type(LectureQualType.REQUIRED)
+				.text("프로그래밍 기초 지식")
+				.build();
+
+		return Lecture.builder()
+				.lectureId(19L)
+				.orgId(1L)
+				.orgName("테스트 기관")
+				.lectureName("Spring Boot 마스터")
+				.days(Set.of(LectureDay.MONDAY, LectureDay.WEDNESDAY, LectureDay.FRIDAY))
+				.startTime(LocalTime.of(9, 0))
+				.endTime(LocalTime.of(18, 0))
+				.lectureLoc(LectureLocation.OFFLINE)
+				.location("서울시 강남구")
+				.recruitType(RecruitType.CARD_REQUIRED)
+				.subsidy(BigDecimal.valueOf(1000000))
+				.lectureFee(BigDecimal.valueOf(5000000))
+				.status(LectureStatus.RECRUITING)
+				.lectureAuthStatus(LectureAuthStatus.APPROVED)
+				.startAt(LocalDateTime.of(2025, 3, 1, 0, 0))
+				.endAt(LocalDateTime.of(2025, 6, 30, 0, 0))
+				.deadline(LocalDateTime.of(2025, 2, 28, 23, 59))
+				.steps(List.of(step))
+				.adds(List.of(add))
+				.quals(List.of(qual))
+				.teachers(List.of(teacher))
+				.lectureCurriculums(List.of(lectureCurriculum))
+				.build();
+	}
+}


### PR DESCRIPTION
## 문제
Redis에서 캐시된 `Lecture` 객체를 역직렬화할 때 에러 발생:
```
Cannot construct instance of `com.swcampus.domain.lecture.Lecture` 
(no Creators, like default constructor, exist)
```

## 원인
- Domain 클래스들이 `@Builder`만 사용하여 기본 생성자가 없었음
- Jackson이 JSON을 객체로 역직렬화할 때 기본 생성자 필요

## 해결
Domain 클래스에 `@NoArgsConstructor(access = AccessLevel.PRIVATE)` 추가

### 수정된 파일
- `Lecture.java`
- `LectureStep.java`
- `LectureAdd.java`
- `LectureQual.java`
- `LectureCurriculum.java`
- `Teacher.java`
- `Curriculum.java`
- `Category.java`

## 테스트
- Jackson 직렬화/역직렬화 단위 테스트 추가
- `LectureCacheSerializationTest.java`

## 배포 후 조치
기존 캐시는 TTL(30분) 만료 후 자동 갱신됨
(즉시 적용 필요시: `redis-cli KEYS "lecture:*" | xargs redis-cli DEL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)