### PR TITLE
fix(storage): 비로그인 사용자 접근 시 ClassCastException 수정

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/security/OptionalCurrentMember.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/security/OptionalCurrentMember.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-@AuthenticationPrincipal
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this")
 @Parameter(hidden = true)
 public @interface OptionalCurrentMember {
 }

--- a/sw-campus-api/src/main/java/com/swcampus/api/storage/StorageController.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/storage/StorageController.java
@@ -1,6 +1,7 @@
 package com.swcampus.api.storage;
 
 import com.swcampus.api.security.CurrentMember;
+import com.swcampus.api.security.OptionalCurrentMember;
 import com.swcampus.api.storage.request.PresignedUrlBatchRequest;
 import com.swcampus.api.storage.request.PresignedUploadRequest;
 import com.swcampus.api.storage.response.PresignedUploadResponse;
@@ -21,7 +22,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -47,8 +47,7 @@ public class StorageController {
     public ResponseEntity<PresignedUrlResponse> getPresignedUrl(
             @Parameter(description = "S3 객체 key", required = true, example = "lectures/2024/01/01/uuid.jpg")
             @RequestParam("key") String key,
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") MemberPrincipal member) {
+            @OptionalCurrentMember MemberPrincipal member) {
 
         boolean isAdmin = isAdmin(member);
         var presignedUrl = presignedUrlService.getPresignedUrl(key, isAdmin);
@@ -68,8 +67,7 @@ public class StorageController {
     @PostMapping("/presigned-urls/batch")
     public ResponseEntity<Map<String, String>> getPresignedUrlBatch(
             @Valid @RequestBody PresignedUrlBatchRequest request,
-            @Parameter(hidden = true)
-            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") MemberPrincipal member) {
+            @OptionalCurrentMember MemberPrincipal member) {
 
         boolean isAdmin = isAdmin(member);
         var urls = presignedUrlService.getPresignedUrls(request.keys(), isAdmin);


### PR DESCRIPTION
## 📋 PR 요약

비로그인 상태에서 Storage API 호출 시 발생하는 `ClassCastException` 버그를 수정합니다.

## 🔗 관련 이슈

closes #349

## 📝 변경 사항

- `@AuthenticationPrincipal`에 SpEL expression 추가
- `anonymousUser`일 경우 `null` 반환하도록 처리
- `permitAll()` 설정된 API에서 비로그인 사용자도 정상 처리 가능

## 🐛 수정된 버그

```java
// 변경 전
@AuthenticationPrincipal MemberPrincipal member

// 변경 후
@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") MemberPrincipal member
```

## 💬 리뷰어에게

- `isAdmin()` 메서드가 이미 null 체크를 하고 있어 추가 수정 불필요
- 비로그인 시 `member = null` → `isAdmin = false` → Public 파일만 접근 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)