### PR TITLE
hotfix: 강의 정렬 로직 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ scripts/data-migration/output/
 
 ### Google Analytics ###
 *-ga-credentials.json
+
+.sdkmanrc

--- a/sw-campus-infra/db-postgres/src/main/resources/mapper/lecture/LectureMapper.xml
+++ b/sw-campus-infra/db-postgres/src/main/resources/mapper/lecture/LectureMapper.xml
@@ -239,7 +239,7 @@
                     ORDER BY lecture_fee DESC, updated_at DESC
                 </when>
                 <when test="cond.sort.name() == 'START_SOON'">
-                    ORDER BY deadline ASC NULLS LAST, updated_at DESC
+                    ORDER BY CASE WHEN status = 'RECRUITING' THEN 0 ELSE 1 END, deadline ASC NULLS LAST, updated_at DESC
                 </when>
                 <when test="cond.sort.name() == 'DURATION_ASC'">
                     ORDER BY total_days ASC NULLS LAST, updated_at DESC
@@ -254,7 +254,7 @@
                     ORDER BY average_score DESC, updated_at DESC
                 </when>
                 <otherwise>
-                    ORDER BY updated_at DESC
+                    ORDER BY CASE WHEN status = 'RECRUITING' THEN 0 ELSE 1 END, updated_at DESC
                 </otherwise>
             </choose>
             
@@ -272,7 +272,7 @@
                 ORDER BY paged.lecture_fee DESC, paged.updated_at DESC, s_steps.step_order ASC
             </when>
             <when test="cond.sort.name() == 'START_SOON'">
-                ORDER BY paged.deadline ASC NULLS LAST, paged.updated_at DESC, s_steps.step_order ASC
+                ORDER BY CASE WHEN paged.status = 'RECRUITING' THEN 0 ELSE 1 END, paged.deadline ASC NULLS LAST, paged.updated_at DESC, s_steps.step_order ASC
             </when>
             <when test="cond.sort.name() == 'DURATION_ASC'">
                 ORDER BY paged.total_days ASC NULLS LAST, paged.updated_at DESC, s_steps.step_order ASC
@@ -287,7 +287,7 @@
                 ORDER BY paged.average_score DESC, paged.updated_at DESC, s_steps.step_order ASC
             </when>
             <otherwise>
-                ORDER BY paged.updated_at DESC, s_steps.step_order ASC
+                ORDER BY CASE WHEN paged.status = 'RECRUITING' THEN 0 ELSE 1 END, paged.updated_at DESC, s_steps.step_order ASC
             </otherwise>
         </choose>
     </select>


### PR DESCRIPTION
## 📋 PR 요약

강의 목록 조회 시 정렬 로직 개선 - 모집중 강의가 우선 표시되도록 수정

## 🔗 관련 이슈

- 운영 중 발견된 정렬 이슈 수정

## 📝 변경 사항

- 최신순(LATEST) 정렬: 모집중 강의 우선 → 업데이트 순
- 마감임박순(START_SOON) 정렬: 모집중 강의 우선 → 마감일 가까운 순
- .gitignore에 .sdkmanrc 추가

## 💬 리뷰어에게 (선택)

기존에는 updatedAt 기준으로만 정렬되어 수정된 강의가 상단에 올라오는 문제가 있었습니다.
이제 모집중 강의가 먼저 표시되고, 그 안에서 정렬 조건이 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)