### PR TITLE
develop to main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,9 +71,6 @@ project(':sw-campus-api') {
 
     bootJar {
         enabled = true
-        from(project(':sw-campus-infra:db-postgres').sourceSets.main.resources) {
-        into('BOOT-INF/classes')
-        }
     }
 
     jar {


### PR DESCRIPTION
bootJar에서 db-postgres 리소스를 BOOT-INF/classes로 복사하는 로직 제거
- 동일 mapper XML이 BOOT-INF/classes와 BOOT-INF/lib/db-postgres.jar에 중복 존재
- MyBatis가 두 위치 모두에서 로드하여 ResultMap 중복 정의 에러 발생
- dependency jar에만 mapper XML이 포함되도록 수정

## 📋 PR 요약

<!-- 이 PR에서 변경한 내용을 간단히 설명해주세요 -->

## 🔗 관련 이슈

closes #

## 📝 변경 사항

- 

## 💬 리뷰어에게 (선택)

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
