### PR TITLE
feat: 특화 커리큘럼 기능 추가

### DIFF
--- a/sw-campus-api/src/main/java/com/swcampus/api/lecture/request/LectureCreateRequest.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/lecture/request/LectureCreateRequest.java
@@ -18,10 +18,14 @@ import com.swcampus.domain.lecture.LectureDay;
 import com.swcampus.domain.lecture.LectureLocation;
 import com.swcampus.domain.lecture.LectureQual;
 import com.swcampus.domain.lecture.LectureQualType;
+import com.swcampus.domain.lecture.LectureSpecialCurriculum;
 import com.swcampus.domain.lecture.LectureStep;
 import com.swcampus.domain.lecture.RecruitType;
 import com.swcampus.domain.lecture.SelectionStepType;
 import com.swcampus.domain.teacher.Teacher;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -96,7 +100,10 @@ public record LectureCreateRequest(
 
 		@Schema(description = "강사 목록") List<TeacherRequest> teachers,
 
-		@Schema(description = "커리큘럼 목록") List<CurriculumRequest> curriculums) {
+		@Schema(description = "커리큘럼 목록") List<CurriculumRequest> curriculums,
+
+		@Size(max = 5, message = "특화 커리큘럼은 최대 5개까지 등록할 수 있습니다")
+		@Schema(description = "특화 커리큘럼 목록 (최대 5개)") List<SpecialCurriculumRequest> specialCurriculums) {
 
 	public Lecture toDomain() {
 		return Lecture.builder()
@@ -163,6 +170,11 @@ public record LectureCreateRequest(
 						? curriculums.stream().map(CurriculumRequest::toDomainInfo).toList()
 						: List.of())
 
+				// 특화 커리큘럼(SpecialCurriculums) 변환
+				.specialCurriculums(specialCurriculums != null
+						? specialCurriculums.stream().map(SpecialCurriculumRequest::toDomain).toList()
+						: List.of())
+
 				.build();
 	}
 
@@ -226,6 +238,23 @@ public record LectureCreateRequest(
 			return LectureCurriculum.builder()
 					.curriculumId(curriculumId)
 					.level(level != null ? level : CurriculumLevel.NONE)
+					.build();
+		}
+	}
+
+	@Schema(description = "특화 커리큘럼")
+	public record SpecialCurriculumRequest(
+			@NotBlank(message = "특화 커리큘럼 제목은 필수입니다")
+			@Size(max = 20, message = "특화 커리큘럼 제목은 20자 이내로 입력해주세요")
+			@Schema(description = "제목", example = "AI 프로젝트") String title,
+
+			@NotNull(message = "정렬 순서는 필수입니다")
+			@Min(value = 1, message = "정렬 순서는 1 이상이어야 합니다")
+			@Schema(description = "정렬 순서", example = "1") Integer sortOrder) {
+		public LectureSpecialCurriculum toDomain() {
+			return LectureSpecialCurriculum.builder()
+					.title(title)
+					.sortOrder(sortOrder)
 					.build();
 		}
 	}

--- a/sw-campus-api/src/main/java/com/swcampus/api/lecture/request/LectureUpdateRequest.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/lecture/request/LectureUpdateRequest.java
@@ -20,10 +20,13 @@ import com.swcampus.domain.lecture.LectureDay;
 import com.swcampus.domain.lecture.LectureLocation;
 import com.swcampus.domain.lecture.LectureQual;
 import com.swcampus.domain.lecture.LectureQualType;
+import com.swcampus.domain.lecture.LectureSpecialCurriculum;
 import com.swcampus.domain.lecture.LectureStep;
 import com.swcampus.domain.lecture.RecruitType;
 import com.swcampus.domain.lecture.SelectionStepType;
 import com.swcampus.domain.teacher.Teacher;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -99,7 +102,10 @@ public record LectureUpdateRequest(
 
         @Schema(description = "강사 목록") List<TeacherRequest> teachers,
 
-        @Schema(description = "커리큘럼 목록") List<CurriculumRequest> curriculums) {
+        @Schema(description = "커리큘럼 목록") List<CurriculumRequest> curriculums,
+
+        @Size(max = 5, message = "특화 커리큘럼은 최대 5개까지 등록할 수 있습니다")
+        @Schema(description = "특화 커리큘럼 목록 (최대 5개)") List<SpecialCurriculumRequest> specialCurriculums) {
 
     public Lecture toDomain() {
         return Lecture.builder()
@@ -166,6 +172,11 @@ public record LectureUpdateRequest(
                         ? curriculums.stream().map(CurriculumRequest::toDomainInfo).toList()
                         : List.of())
 
+                // 특화 커리큘럼(SpecialCurriculums) 변환
+                .specialCurriculums(specialCurriculums != null
+                        ? specialCurriculums.stream().map(SpecialCurriculumRequest::toDomain).toList()
+                        : List.of())
+
                 .build();
     }
 
@@ -229,6 +240,23 @@ public record LectureUpdateRequest(
             return LectureCurriculum.builder()
                     .curriculumId(curriculumId)
                     .level(level != null ? level : CurriculumLevel.NONE)
+                    .build();
+        }
+    }
+
+    @Schema(description = "특화 커리큘럼")
+    public record SpecialCurriculumRequest(
+            @NotBlank(message = "특화 커리큘럼 제목은 필수입니다")
+            @Size(max = 20, message = "특화 커리큘럼 제목은 20자 이내로 입력해주세요")
+            @Schema(description = "제목", example = "AI 프로젝트") String title,
+
+            @NotNull(message = "정렬 순서는 필수입니다")
+            @Min(value = 1, message = "정렬 순서는 1 이상이어야 합니다")
+            @Schema(description = "정렬 순서", example = "1") Integer sortOrder) {
+        public LectureSpecialCurriculum toDomain() {
+            return LectureSpecialCurriculum.builder()
+                    .title(title)
+                    .sortOrder(sortOrder)
                     .build();
         }
     }

--- a/sw-campus-api/src/main/java/com/swcampus/api/lecture/response/LectureResponse.java
+++ b/sw-campus-api/src/main/java/com/swcampus/api/lecture/response/LectureResponse.java
@@ -12,6 +12,7 @@ import com.swcampus.domain.lecture.Lecture;
 import com.swcampus.domain.lecture.LectureAdd;
 import com.swcampus.domain.lecture.LectureCurriculum;
 import com.swcampus.domain.lecture.LectureQual;
+import com.swcampus.domain.lecture.LectureSpecialCurriculum;
 import com.swcampus.domain.lecture.LectureStep;
 import com.swcampus.domain.organization.Organization;
 import com.swcampus.domain.teacher.Teacher;
@@ -106,6 +107,8 @@ public record LectureResponse(
 
 		@Schema(description = "커리큘럼 목록") List<CurriculumResponse> curriculums,
 
+		@Schema(description = "특화 커리큘럼 목록") List<SpecialCurriculumResponse> specialCurriculums,
+
 		@Schema(description = "기관 로고 이미지 URL", example = "https://example.com/logo.jpg") String orgLogoUrl,
 
 		@Schema(description = "기관 시설 이미지 URL 목록") List<String> orgFacilityImageUrls,
@@ -171,6 +174,7 @@ public record LectureResponse(
 				mapListSafe(lecture.getTeachers(), TeacherResponse::from),
 				extractCategoryName(lecture),
 				mapListSafe(lecture.getLectureCurriculums(), CurriculumResponse::from),
+				mapListSafe(lecture.getSpecialCurriculums(), SpecialCurriculumResponse::from),
 				organization != null ? organization.getLogoUrl() : null,
 				extractFacilityImageUrls(organization),
 
@@ -281,6 +285,21 @@ public record LectureResponse(
 					curriculum != null ? curriculum.getCurriculumName() : "",
 					curriculum != null ? curriculum.getCurriculumDesc() : "",
 					lc.getLevel().name());
+		}
+	}
+
+	@Schema(description = "특화 커리큘럼 응답")
+	public record SpecialCurriculumResponse(
+			@Schema(description = "특화 커리큘럼 ID", example = "1") Long specialCurriculumId,
+
+			@Schema(description = "제목", example = "AI 프로젝트") String title,
+
+			@Schema(description = "정렬 순서", example = "1") Integer sortOrder) {
+		public static SpecialCurriculumResponse from(LectureSpecialCurriculum sc) {
+			return new SpecialCurriculumResponse(
+					sc.getSpecialCurriculumId(),
+					sc.getTitle(),
+					sc.getSortOrder());
 		}
 	}
 }

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/Lecture.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/Lecture.java
@@ -70,6 +70,9 @@ public class Lecture {
 	private List<com.swcampus.domain.teacher.Teacher> teachers;
 	private List<LectureCurriculum> lectureCurriculums;
 
+	// 1:N Relationships (SpecialCurriculums)
+	private List<LectureSpecialCurriculum> specialCurriculums;
+
 	public Lecture close() {
 		return this.toBuilder()
 				.status(LectureStatus.FINISHED)

--- a/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureSpecialCurriculum.java
+++ b/sw-campus-domain/src/main/java/com/swcampus/domain/lecture/LectureSpecialCurriculum.java
@@ -1,0 +1,18 @@
+package com.swcampus.domain.lecture;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class LectureSpecialCurriculum {
+	private Long specialCurriculumId;
+	private Long lectureId;
+	private String title;
+	private Integer sortOrder;
+}

--- a/sw-campus-domain/src/test/java/com/swcampus/domain/lecture/LectureSpecialCurriculumTest.java
+++ b/sw-campus-domain/src/test/java/com/swcampus/domain/lecture/LectureSpecialCurriculumTest.java
@@ -1,0 +1,191 @@
+package com.swcampus.domain.lecture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LectureSpecialCurriculumTest {
+
+	@Nested
+	@DisplayName("LectureSpecialCurriculum 생성 테스트")
+	class CreateTest {
+
+		@Test
+		@DisplayName("빌더로 특화 커리큘럼 생성 성공")
+		void create_withBuilder_success() {
+			// given & when
+			LectureSpecialCurriculum curriculum = LectureSpecialCurriculum.builder()
+					.specialCurriculumId(1L)
+					.lectureId(100L)
+					.title("실무 프로젝트")
+					.sortOrder(1)
+					.build();
+
+			// then
+			assertThat(curriculum.getSpecialCurriculumId()).isEqualTo(1L);
+			assertThat(curriculum.getLectureId()).isEqualTo(100L);
+			assertThat(curriculum.getTitle()).isEqualTo("실무 프로젝트");
+			assertThat(curriculum.getSortOrder()).isEqualTo(1);
+		}
+
+		@Test
+		@DisplayName("정렬 순서 지정하여 특화 커리큘럼 생성 성공")
+		void create_withSortOrder_success() {
+			// given & when
+			LectureSpecialCurriculum curriculum = LectureSpecialCurriculum.builder()
+					.specialCurriculumId(1L)
+					.lectureId(100L)
+					.title("AI 특강")
+					.sortOrder(2)
+					.build();
+
+			// then
+			assertThat(curriculum.getTitle()).isEqualTo("AI 특강");
+			assertThat(curriculum.getSortOrder()).isEqualTo(2);
+		}
+
+		@Test
+		@DisplayName("ID 없이 새 특화 커리큘럼 생성 (저장 전)")
+		void create_withoutId_forNewCurriculum() {
+			// given & when
+			LectureSpecialCurriculum curriculum = LectureSpecialCurriculum.builder()
+					.lectureId(100L)
+					.title("멘토링 프로그램")
+					.sortOrder(3)
+					.build();
+
+			// then
+			assertThat(curriculum.getSpecialCurriculumId()).isNull();
+			assertThat(curriculum.getLectureId()).isEqualTo(100L);
+			assertThat(curriculum.getTitle()).isEqualTo("멘토링 프로그램");
+		}
+	}
+
+	@Nested
+	@DisplayName("Lecture와 SpecialCurriculums 통합 테스트")
+	class LectureIntegrationTest {
+
+		@Test
+		@DisplayName("Lecture에 특화 커리큘럼 목록 포함")
+		void lecture_withSpecialCurriculums() {
+			// given
+			List<LectureSpecialCurriculum> specialCurriculums = List.of(
+					LectureSpecialCurriculum.builder()
+							.specialCurriculumId(1L)
+							.lectureId(100L)
+							.title("실무 프로젝트")
+							.sortOrder(1)
+							.build(),
+					LectureSpecialCurriculum.builder()
+							.specialCurriculumId(2L)
+							.lectureId(100L)
+							.title("취업 특강")
+							.sortOrder(2)
+							.build()
+			);
+
+			// when
+			Lecture lecture = Lecture.builder()
+					.lectureId(100L)
+					.lectureName("Java 백엔드 부트캠프")
+					.specialCurriculums(specialCurriculums)
+					.build();
+
+			// then
+			assertThat(lecture.getSpecialCurriculums()).hasSize(2);
+			assertThat(lecture.getSpecialCurriculums().get(0).getTitle()).isEqualTo("실무 프로젝트");
+			assertThat(lecture.getSpecialCurriculums().get(1).getTitle()).isEqualTo("취업 특강");
+		}
+
+		@Test
+		@DisplayName("Lecture에 특화 커리큘럼 없음")
+		void lecture_withoutSpecialCurriculums() {
+			// when
+			Lecture lecture = Lecture.builder()
+					.lectureId(100L)
+					.lectureName("기본 강의")
+					.specialCurriculums(null)
+					.build();
+
+			// then
+			assertThat(lecture.getSpecialCurriculums()).isNull();
+		}
+
+		@Test
+		@DisplayName("Lecture에 빈 특화 커리큘럼 목록")
+		void lecture_withEmptySpecialCurriculums() {
+			// when
+			Lecture lecture = Lecture.builder()
+					.lectureId(100L)
+					.lectureName("기본 강의")
+					.specialCurriculums(List.of())
+					.build();
+
+			// then
+			assertThat(lecture.getSpecialCurriculums()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("특화 커리큘럼 최대 5개 시나리오")
+		void lecture_withMaxFiveSpecialCurriculums() {
+			// given
+			List<LectureSpecialCurriculum> specialCurriculums = List.of(
+					createCurriculum(1L, "실무 프로젝트", 1),
+					createCurriculum(2L, "취업 특강", 2),
+					createCurriculum(3L, "멘토링", 3),
+					createCurriculum(4L, "네트워킹", 4),
+					createCurriculum(5L, "포트폴리오 리뷰", 5)
+			);
+
+			// when
+			Lecture lecture = Lecture.builder()
+					.lectureId(100L)
+					.lectureName("풀스택 부트캠프")
+					.specialCurriculums(specialCurriculums)
+					.build();
+
+			// then
+			assertThat(lecture.getSpecialCurriculums()).hasSize(5);
+		}
+
+		@Test
+		@DisplayName("특화 커리큘럼 정렬 순서 확인")
+		void lecture_specialCurriculums_sortOrder() {
+			// given
+			List<LectureSpecialCurriculum> specialCurriculums = List.of(
+					createCurriculum(3L, "세 번째", 3),
+					createCurriculum(1L, "첫 번째", 1),
+					createCurriculum(2L, "두 번째", 2)
+			);
+
+			// when
+			Lecture lecture = Lecture.builder()
+					.lectureId(100L)
+					.specialCurriculums(specialCurriculums)
+					.build();
+
+			// 정렬
+			List<LectureSpecialCurriculum> sorted = lecture.getSpecialCurriculums().stream()
+					.sorted((a, b) -> a.getSortOrder().compareTo(b.getSortOrder()))
+					.toList();
+
+			// then
+			assertThat(sorted.get(0).getTitle()).isEqualTo("첫 번째");
+			assertThat(sorted.get(1).getTitle()).isEqualTo("두 번째");
+			assertThat(sorted.get(2).getTitle()).isEqualTo("세 번째");
+		}
+
+		private LectureSpecialCurriculum createCurriculum(Long id, String title, int sortOrder) {
+			return LectureSpecialCurriculum.builder()
+					.specialCurriculumId(id)
+					.lectureId(100L)
+					.title(title)
+					.sortOrder(sortOrder)
+					.build();
+		}
+	}
+}

--- a/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureEntity.java
+++ b/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureEntity.java
@@ -38,7 +38,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString(exclude = { "steps", "adds", "quals", "lectureTeachers", "lectureCurriculums" })
+@ToString(exclude = { "steps", "adds", "quals", "lectureTeachers", "lectureCurriculums", "specialCurriculums" })
 public class LectureEntity {
 
 	@Id
@@ -216,6 +216,10 @@ public class LectureEntity {
 	@Builder.Default
 	private List<LectureCurriculumEntity> lectureCurriculums = new ArrayList<>();
 
+	@OneToMany(mappedBy = "lecture", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<LectureSpecialCurriculumEntity> specialCurriculums = new ArrayList<>();
+
 	public static LectureEntity from(com.swcampus.domain.lecture.Lecture lecture) {
 		if (lecture == null) {
 			return null;
@@ -303,6 +307,18 @@ public class LectureEntity {
 					.toList());
 		}
 
+		// 1:N Relationships (SpecialCurriculums)
+		if (lecture.getSpecialCurriculums() != null) {
+			entity.getSpecialCurriculums().addAll(lecture.getSpecialCurriculums().stream()
+					.map(sc -> LectureSpecialCurriculumEntity.builder()
+							.specialCurriculumId(sc.getSpecialCurriculumId())
+							.lecture(entity)
+							.title(sc.getTitle())
+							.sortOrder(sc.getSortOrder())
+							.build())
+					.toList());
+		}
+
 		return entity;
 	}
 
@@ -339,6 +355,9 @@ public class LectureEntity {
 						.toList())
 				.lectureCurriculums(lectureCurriculums.stream()
 						.map(LectureCurriculumEntity::toDomain)
+						.toList())
+				.specialCurriculums(specialCurriculums.stream()
+						.map(LectureSpecialCurriculumEntity::toDomain)
 						.toList())
 				.build();
 	}

--- a/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureEntityRepository.java
+++ b/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureEntityRepository.java
@@ -74,6 +74,8 @@ public class LectureEntityRepository implements LectureRepository {
 		entity.getAdds().clear();
 		// 1:N Quals
 		entity.getQuals().clear();
+		// 1:N SpecialCurriculums
+		entity.getSpecialCurriculums().clear();
 		// N:M Teachers
 		entity.getLectureTeachers().clear();
 		// N:M Curriculums
@@ -142,6 +144,17 @@ public class LectureEntityRepository implements LectureRepository {
 						.level(lc.getLevel())
 						.build());
 			});
+		}
+
+		// 1:N SpecialCurriculums
+		if (lecture.getSpecialCurriculums() != null) {
+			entity.getSpecialCurriculums().addAll(lecture.getSpecialCurriculums().stream()
+					.map(sc -> LectureSpecialCurriculumEntity.builder()
+							.lecture(entity)
+							.title(sc.getTitle())
+							.sortOrder(sc.getSortOrder())
+							.build())
+					.toList());
 		}
 	}
 

--- a/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureSpecialCurriculumEntity.java
+++ b/sw-campus-infra/db-postgres/src/main/java/com/swcampus/infra/postgres/lecture/LectureSpecialCurriculumEntity.java
@@ -1,0 +1,53 @@
+package com.swcampus.infra.postgres.lecture;
+
+import com.swcampus.domain.lecture.LectureSpecialCurriculum;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Table(name = "LECTURE_SPECIAL_CURRICULUMS")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString(exclude = "lecture")
+public class LectureSpecialCurriculumEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "lecture_special_curriculums_seq")
+	@SequenceGenerator(name = "lecture_special_curriculums_seq", sequenceName = "lecture_special_curriculums_special_curriculum_id_seq", allocationSize = 1)
+	@Column(name = "SPECIAL_CURRICULUM_ID")
+	private Long specialCurriculumId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "LECTURE_ID")
+	private LectureEntity lecture;
+
+	@Column(name = "TITLE", nullable = false, length = 20)
+	private String title;
+
+	@Column(name = "SORT_ORDER", nullable = false)
+	private Integer sortOrder;
+
+	public LectureSpecialCurriculum toDomain() {
+		return LectureSpecialCurriculum.builder()
+				.specialCurriculumId(specialCurriculumId)
+				.lectureId(lecture.getLectureId())
+				.title(title)
+				.sortOrder(sortOrder)
+				.build();
+	}
+}

--- a/sw-campus-infra/db-postgres/src/main/resources/db/migration/V11__add_lecture_special_curriculums.sql
+++ b/sw-campus-infra/db-postgres/src/main/resources/db/migration/V11__add_lecture_special_curriculums.sql
@@ -1,0 +1,26 @@
+-- V11: Add lecture special curriculums table
+-- 강의별 특화 커리큘럼 기능 추가 (최대 5개, 제목만)
+
+-- Sequence 생성
+CREATE SEQUENCE swcampus.lecture_special_curriculums_special_curriculum_id_seq;
+
+-- Table 생성
+CREATE TABLE swcampus.lecture_special_curriculums (
+    special_curriculum_id BIGINT NOT NULL DEFAULT nextval('swcampus.lecture_special_curriculums_special_curriculum_id_seq'),
+    lecture_id BIGINT NOT NULL,
+    title VARCHAR(20) NOT NULL,
+    sort_order INTEGER NOT NULL,
+    CONSTRAINT lecture_special_curriculums_pkey PRIMARY KEY (special_curriculum_id),
+    CONSTRAINT fk_lecture_special_curriculums_lecture FOREIGN KEY (lecture_id)
+        REFERENCES swcampus.lectures(lecture_id) ON DELETE CASCADE
+);
+
+-- Index 생성
+CREATE INDEX idx_lecture_special_curriculums_lecture_id
+    ON swcampus.lecture_special_curriculums(lecture_id);
+
+COMMENT ON TABLE swcampus.lecture_special_curriculums IS '강의별 특화 커리큘럼 (최대 5개, 제목만)';
+COMMENT ON COLUMN swcampus.lecture_special_curriculums.special_curriculum_id IS '특화 커리큘럼 ID';
+COMMENT ON COLUMN swcampus.lecture_special_curriculums.lecture_id IS '강의 ID';
+COMMENT ON COLUMN swcampus.lecture_special_curriculums.title IS '커리큘럼 제목 (최대 20자)';
+COMMENT ON COLUMN swcampus.lecture_special_curriculums.sort_order IS '정렬 순서';


### PR DESCRIPTION
## Summary
- LectureSpecialCurriculum 도메인 모델 추가 (title, sortOrder 필드)
- LectureSpecialCurriculumEntity JPA 엔티티 추가 (CascadeType.ALL, orphanRemoval 설정)
- LectureCreateRequest/UpdateRequest에 특화 커리큘럼 입력 필드 추가
- LectureResponse에 특화 커리큘럼 응답 필드 추가
- V11 마이그레이션: lecture_special_curriculums 테이블 생성

## Test plan
- [ ] 강의 생성 API 호출 시 특화 커리큘럼 데이터 저장 확인
- [ ] 강의 수정 API 호출 시 특화 커리큘럼 데이터 업데이트 확인
- [ ] 강의 상세 조회 API 응답에 특화 커리큘럼 포함 확인
- [ ] 특화 커리큘럼 삭제 시 orphanRemoval 동작 확인
- [ ] sortOrder 순서대로 데이터 정렬 확인

🤖 Generated with [Claude Code](https://claude.ai/code)